### PR TITLE
Merge updated CMakeFiles from FLEXI into HOPR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,34 @@ INCLUDE(ExternalProject)
 INCLUDE(CMakeDependentOption)
 
 # =========================================================================
+# Check gold support
+# =========================================================================
+EXECUTE_PROCESS(COMMAND ld.gold --version COMMAND grep "^GNU gold" COMMAND sed "s/^.* //g" OUTPUT_VARIABLE GNU_GOLD_VERSION)
+IF (DEFINED GNU_GOLD_VERSION  AND NOT "${GNU_GOLD_VERSION}" STREQUAL "")
+  STRING(STRIP "${GNU_GOLD_VERSION}" GNU_GOLD_VERSION)
+  MESSAGE(STATUS "Setting linker to gold v${GNU_GOLD_VERSION}")
+  # Shift responsibility of driving the final stages of compilation from collect2 to gold via the linker plugin
+  # More information at: https://gcc.gnu.org/wiki/LinkTimeOptimization
+  IF(CMAKE_VERSION VERSION_GREATER_EQUAL 3.13)
+    ADD_LINK_OPTIONS("-fuse-ld=gold")
+    # Make it abundantly clear we want to use gold
+    FIND_PROGRAM(CMAKE_GOLD_LINKER NAMES ${_CMAKE_TOOLCHAIN_PREFIX}ld.gold${_CMAKE_TOOLCHAIN_SUFFIX} HINTS ${_CMAKE_TOOLCHAIN_LOCATION})
+    SET (CMAKE_LINKER "${CMAKE_GOLD_LINKER}" CACHE FILEPATH "" FORCE)
+    MARK_AS_ADVANCED(FORCE CMAKE_GOLD_LINKER)
+  ELSE()
+    SET (CMAKE_EXE_LINKER_FLAGS    "${CMAKE_EXE_LINKER_FLAGS}    -fuse-ld=gold")
+    SET (CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -fuse-ld=gold")
+    # This currently breaks ar (binutils archiver)
+    # SET (CMAKE_STATIC_LINKER_FLAGS "${CMAKE_STATIC_LINKER_FLAGS} -fuse-ld=gold")
+    SET (CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -fuse-ld=gold")
+    # Make it abundantly clear we want to use gold
+    FIND_PROGRAM(CMAKE_GOLD_LINKER NAMES ${_CMAKE_TOOLCHAIN_PREFIX}ld.gold${_CMAKE_TOOLCHAIN_SUFFIX} HINTS ${_CMAKE_TOOLCHAIN_LOCATION})
+    SET (CMAKE_LINKER "${CMAKE_GOLD_LINKER}" CACHE FILEPATH "" FORCE)
+    MARK_AS_ADVANCED(FORCE CMAKE_GOLD_LINKER)
+  ENDIF()
+ENDIF()
+
+# =========================================================================
 # Machine environment
 # =========================================================================
 INCLUDE(${CMAKE_CURRENT_SOURCE_DIR}/CMakeListsMachine.txt)
@@ -27,6 +55,21 @@ INCLUDE(${CMAKE_CURRENT_SOURCE_DIR}/CMakeListsMachine.txt)
 # =========================================================================
 PROJECT(Hopr)
 
+# =========================================================================
+# Check IPO support:
+# =========================================================================
+# we need to have languages enabled and compilers defined for this
+IF(NOT(${CMAKE_VERSION} VERSION_LESS "3.9.0"))
+  CMAKE_POLICY(SET CMP0069 NEW)
+  INCLUDE(CheckIPOSupported)
+  CHECK_IPO_SUPPORTED(RESULT HASIPO OUTPUT error)
+ELSE()
+  SET(HASIPO FALSE)
+ENDIF()
+
+# =========================================================================
+# Output paths
+# =========================================================================
 SET(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/bin)
 SET(CMAKE_Fortran_MODULE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/include)
 SET(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/lib)
@@ -43,16 +86,61 @@ ENDIF()
 # =========================================================================
 # make sure that the default is a RELEASE
 IF (NOT CMAKE_BUILD_TYPE)
-  SET (CMAKE_BUILD_TYPE Release CACHE STRING
-      "Choose the type of build, options are: Debug Release Profile."
-      FORCE)
-  SET_PROPERTY(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS Debug Release Profile)
+  SET (CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build, options are: Debug, Release, Profile, Sanitize (only GNU))." FORCE)
+   IF (CMAKE_Fortran_COMPILER_ID MATCHES "GNU")
+     SET_PROPERTY(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS Debug Release Profile Sanitize)
+   ELSEIF (CMAKE_Fortran_COMPILER_ID MATCHES "Intel")
+     SET_PROPERTY(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS Debug Release Profile)
+   ELSEIF (CMAKE_Fortran_COMPILER_ID MATCHES "Cray")
+     SET_PROPERTY(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS Debug Release Profile)
+   ENDIF()
 ENDIF (NOT CMAKE_BUILD_TYPE)
+
+
+STRING(TOLOWER ${CMAKE_BUILD_TYPE} BUILD_TYPE_LC)
+IF (NOT BUILD_TYPE_LC MATCHES "debug" AND NOT BUILD_TYPE_LC MATCHES "sanitize" AND HASIPO)
+  # enable IPO globally (IPO branding: Intel => IPO, GNU => LTO, PGI => IPA)
+  IF (CMAKE_Fortran_COMPILER_ID MATCHES "GNU")
+    # Check the GCC wrapper for the complete toolchain
+    FIND_PROGRAM(CMAKE_GCC_AR     NAMES ${_CMAKE_TOOLCHAIN_PREFIX}gcc-ar${_CMAKE_TOOLCHAIN_SUFFIX} HINTS ${_CMAKE_TOOLCHAIN_LOCATION})
+    FIND_PROGRAM(CMAKE_GCC_NM     NAMES ${_CMAKE_TOOLCHAIN_PREFIX}gcc-nm                           HINTS ${_CMAKE_TOOLCHAIN_LOCATION})
+    FIND_PROGRAM(CMAKE_GCC_RANLIB NAMES ${_CMAKE_TOOLCHAIN_PREFIX}gcc-ranlib                       HINTS ${_CMAKE_TOOLCHAIN_LOCATION})
+    MARK_AS_ADVANCED(FORCE CMAKE_GCC_AR)
+    MARK_AS_ADVANCED(FORCE CMAKE_GCC_NM)
+    MARK_AS_ADVANCED(FORCE CMAKE_GCC_RANLIB)
+    # Do not use the standard CMake LTO option for GNU (-flto -fno-fat-lto-objects), as it does not allow speed-up during linking
+    IF( CMAKE_GCC_AR AND CMAKE_GCC_NM AND CMAKE_GCC_RANLIB )
+      MESSAGE(STATUS "Found GCC binutils wrappers for LTO. Enabling LTO linker plugin.")
+      # Do not use the standard CMake LTO option for GNU (-flto -fno-fat-lto-objects), as it does not allow speed-up during linking
+      SET(CMAKE_INTERPROCEDURAL_OPTIMIZATION FALSE)
+      # Static libraries require either fat LTO objects (increases compilation time) or the use of linker plugins (per default enabled); the jobserver option reduces linking time
+      # More information at: https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+      IF (CMAKE_Fortran_COMPILER_VERSION VERSION_GREATER_EQUAL 10.0)
+        # GCC10 introduced the -flto=auto option, https://gcc.gnu.org/legacy-ml/gcc-patches/2019-07/msg01488.html
+        SET(CMAKE_Fortran_FLAGS  "${CMAKE_Fortran_FLAGS} -flto=auto -fuse-linker-plugin")
+      ELSE()
+        # Otherwise we must rely on hardcoded GCC jobserver. If it is not available, we will get warnings in the console but it still works, albeit in serial mode
+        SET(CMAKE_Fortran_FLAGS  "${CMAKE_Fortran_FLAGS} -flto=jobserver -fuse-linker-plugin")
+      ENDIF()
+      # Use the GCC wrapper for the complete toolchain to provide the path to the linker plugin (this might be the problem with using the CMAKE IPO)
+      SET(CMAKE_AR     "${CMAKE_GCC_AR}"     CACHE FILEPATH "" FORCE)
+      SET(CMAKE_NM     "${CMAKE_GCC_NM}"     CACHE FILEPATH "" FORCE)
+      SET(CMAKE_RANLIB "${CMAKE_GCC_RANLIB}" CACHE FILEPATH "" FORCE)
+      MARK_AS_ADVANCED(FORCE CMAKE_AR)
+      MARK_AS_ADVANCED(FORCE CMAKE_NM)
+      MARK_AS_ADVANCED(FORCE CMAKE_RANLIB)
+    ELSE()
+      MESSAGE(WARNING "GCC indicates LTO support, but binutils wrappers could not be found. Disabling LTO linker plugin." )
+      SET(CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE)  # enable IPO globally
+    ENDIF()
+  ELSE()
+    SET(CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE)  # enable IPO globally
+  ENDIF()
+ENDIF()
 
 # =========================================================================
 # Location of binary and filenames
 # =========================================================================
-
 # append relative filename-macro for __FILENAME__ in Stamp of abort function (see flexi.h)
 SET(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -D__FILENAME__='\"$(subst ${CMAKE_SOURCE_DIR}/,,$(abspath $<))\"'")
 
@@ -62,7 +150,6 @@ ADD_DEFINITIONS("-DBASEDIR='\"${CMAKE_CURRENT_BINARY_DIR}/\"'")
 # =========================================================================
 # USERBLOCK + Preproc_flags
 # =========================================================================
-
 # A function to get all user defined variables with a specified prefix
 function (getListOfVarsStartingWith _prefix _varResult)
     GET_CMAKE_PROPERTY(_vars CACHE_VARIABLES)

--- a/CMakeListsLib.txt
+++ b/CMakeListsLib.txt
@@ -11,11 +11,16 @@ ENDIF()
 MARK_AS_ADVANCED(FORCE LIBS_EXTERNAL_LIB_DIR)
 
 
-# Check whether origin is point to Github or IAG
+# =========================================================================
+# Check where the code originates
+# =========================================================================
 EXECUTE_PROCESS(COMMAND git ls-remote --get-url OUTPUT_VARIABLE GIT_ORIGIN)
 
 # Origin pointing to IAG
 IF("${GIT_ORIGIN}" MATCHES ".iag.uni-stuttgart.de")
+# Strip leading and trailing white space
+STRING(STRIP ${GIT_ORIGIN} GIT_ORIGIN)
+MESSAGE(STATUS "Checking git origin: " ${GIT_ORIGIN})
   # Checked out using SSH
   IF("${GIT_ORIGIN}" MATCHES "^git@")
     SET(LIBS_DLPATH "git@gitlab.iag.uni-stuttgart.de:")
@@ -147,7 +152,7 @@ ELSE()
   # Set HDF5 build dir
   SET(LIBS_HDF5_DIR  ${LIBS_EXTERNAL_LIB_DIR}/HDF5/build)
 
-  # Check if HDF5 was already build
+  # Check if HDF5 was already built
   IF (NOT EXISTS "${LIBS_HDF5_DIR}/lib/libhdf5.a")
     # Set if HDF5 should be built in parallel
     IF(LIBS_USE_MPI)
@@ -160,6 +165,20 @@ ELSE()
       SET(LIBS_HDF5CC ${CMAKE_C_COMPILER} )
     ENDIF()
 
+    # Optional Features:
+    #   --enable-silent-rules   less verbose build output (undo: "make V=1")
+    #   --enable-build-mode=(debug|production|clean)
+    #                           Sets the build mode. Debug turns on symbols, API
+    #                           tracing, asserts, and debug optimization, as well as
+    #                           several other minor configure options that aid in
+    #                           debugging. Production turns high optimizations on.
+    #                           Clean turns nothing on and disables optimization
+    #                           (i.e.: a 'clean slate' configuration). All these
+    #                           settings can be overridden by using specific
+    #                           configure flags. [default=production]
+    #   --disable-dependency-tracking
+    #                           speeds up one-time build
+
     # Let CMake take care of download, configure and build
     ExternalProject_Add(HDF5
       GIT_REPOSITORY ${HDF5_DOWNLOAD}
@@ -168,7 +187,7 @@ ELSE()
       ${${GITSHALLOW}}
       PREFIX ${LIBS_HDF5_DIR}
       UPDATE_COMMAND ""
-      CONFIGURE_COMMAND FC=${LIBS_HDF5FC} CC=${LIBS_HDF5CC} ${LIBS_HDF5_DIR}/src/HDF5/configure --prefix=${LIBS_HDF5_DIR} --with-pic --enable-fortran ${LIBS_HDF5PARALLEL} --libdir=${LIBS_HDF5_DIR}/lib
+      CONFIGURE_COMMAND FC=${LIBS_HDF5FC} CC=${LIBS_HDF5CC} ${LIBS_HDF5_DIR}/src/HDF5/configure --prefix=${LIBS_HDF5_DIR} --with-pic --enable-fortran ${LIBS_HDF5PARALLEL} --libdir=${LIBS_HDF5_DIR}/lib --enable-build-mode=production --enable-silent-rules --disable-dependency-tracking
       BUILD_COMMAND ${MAKE}
     )
     SET(LIBS_HDF5_CMAKE FALSE)

--- a/CMakeListsMachine.txt
+++ b/CMakeListsMachine.txt
@@ -96,31 +96,54 @@ GET_FILENAME_COMPONENT (Fortran_COMPILER_NAME ${CMAKE_Fortran_COMPILER} NAME)
 
 # GNU Compiler Collection (GCC)
 IF (CMAKE_Fortran_COMPILER_ID MATCHES "GNU")
+  # set Flags (disable lto type warnings due to false positives with MATMUL, which is a known bug)
+  IF (NOT DEFINED C_FLAGS_INITIALIZED )
+    SET (C_FLAGS_INITIALIZED "yes" CACHE INTERNAL "Flag if compiler flags are already initialized" )
+    SET (CMAKE_Fortran_FLAGS         "${CMAKE_Fortran_FLAGS} -fdefault-real-8 -fdefault-double-8 -fbackslash -ffree-line-length-0 -Wno-lto-type-mismatch -DGNU")
+  ENDIF()
+  SET (CMAKE_Fortran_FLAGS_RELEASE   "${CMAKE_Fortran_FLAGS}     -O3 ${HOPR_INSTRUCTION} -finline-functions -fstack-arrays")
+  SET (CMAKE_Fortran_FLAGS_PROFILE   "${CMAKE_Fortran_FLAGS} -pg -O3 ${HOPR_INSTRUCTION} -finline-functions -fstack-arrays")
+  SET (CMAKE_Fortran_FLAGS_DEBUG     "${CMAKE_Fortran_FLAGS} -g  -Og -ggdb3 -ffpe-trap=invalid -fbounds-check -finit-real=snan -fbacktrace  -Wall")
+  SET (CMAKE_Fortran_FLAGS_SANITIZE  "${CMAKE_Fortran_FLAGS} -g  -Og -ggdb3 -ffpe-trap=invalid,zero,overflow -fbounds-check -finit-real=snan -fbacktrace  -Wall -fsanitize=address,undefined,leak -fno-omit-frame-pointer -Wc-binding-type -Wuninitialized -pedantic")
+  # add flags only for compiling not linking!
+  SET (HOPR_COMPILE_FLAGS "-xf95-cpp-input -fPIC")
+
+# AMD Optimized LLVM/CLANG
+ELSEIF (CMAKE_Fortran_COMPILER_ID MATCHES "Flang")
   # set Flags
-  SET (CMAKE_Fortran_FLAGS         "${CMAKE_Fortran_FLAGS} -fdefault-real-8 -fdefault-double-8 -fbackslash -ffree-line-length-0 -DGNU")
-  SET (CMAKE_Fortran_FLAGS_RELEASE "${CMAKE_Fortran_FLAGS}     -O3 ${HOPR_INSTRUCTION} -finline-functions")
-  SET (CMAKE_Fortran_FLAGS_PROFILE "${CMAKE_Fortran_FLAGS} -pg -O3 ${HOPR_INSTRUCTION} -finline-functions")
-  SET (CMAKE_Fortran_FLAGS_DEBUG   "${CMAKE_Fortran_FLAGS} -g -O0 -ggdb3 -fbounds-check -finit-real=nan -fbacktrace  -Wall")
+  IF (NOT DEFINED C_FLAGS_INITIALIZED )
+    SET (C_FLAGS_INITIALIZED "yes" CACHE INTERNAL "Flag if compiler flags are already initialized" )
+    SET (CMAKE_Fortran_FLAGS         "${CMAKE_Fortran_FLAGS} -fdefault-real-8 -std=f2008 -DFLANG")
+  ENDIF()
+  SET (CMAKE_Fortran_FLAGS_RELEASE   "${CMAKE_Fortran_FLAGS}     -O3 ${HOPR_INSTRUCTION} -finline-functions ")
+  SET (CMAKE_Fortran_FLAGS_PROFILE   "${CMAKE_Fortran_FLAGS} -pg -O3 ${HOPR_INSTRUCTION} -finline-functions ")
+  SET (CMAKE_Fortran_FLAGS_DEBUG     "${CMAKE_Fortran_FLAGS} -g  -O0 -ggdb3 -ffpe-trap=invalid -fbounds-check -finit-real=snan -fbacktrace  -Wall")
   # add flags only for compiling not linking!
   SET (HOPR_COMPILE_FLAGS "-xf95-cpp-input -fPIC")
 
 # Intel Compiler
 ELSEIF (CMAKE_Fortran_COMPILER_ID MATCHES "Intel")
   # set Flags
-  SET (CMAKE_Fortran_FLAGS         "${CMAKE_Fortran_FLAGS} -r8 -i4 -traceback -warn all -shared-intel -DINTEL")
-  SET (CMAKE_Fortran_FLAGS_RELEASE "${CMAKE_Fortran_FLAGS}    -O2 ${HOPR_INSTRUCTION} -qopt-report0 -qopt-report-phase=vec")
-  SET (CMAKE_Fortran_FLAGS_PROFILE "${CMAKE_Fortran_FLAGS} -p -O2 ${HOPR_INSTRUCTION} -qopt-report0 -qopt-report-phase=vec")
-  SET (CMAKE_Fortran_FLAGS_DEBUG   "${CMAKE_Fortran_FLAGS} -g -O0 -fpe0 -traceback -check all,noarg_temp_created,noformat,nooutput_conversion,pointer,uninit -init=snan -init=arrays")
+  IF (NOT DEFINED C_FLAGS_INITIALIZED )
+    SET (C_FLAGS_INITIALIZED "yes" CACHE INTERNAL "Flag if compiler flags are already initialized" )
+    SET (CMAKE_Fortran_FLAGS         "${CMAKE_Fortran_FLAGS} -r8 -i4 -traceback -warn all -shared-intel -DINTEL")
+  ENDIF()
+  SET (CMAKE_Fortran_FLAGS_RELEASE   "${CMAKE_Fortran_FLAGS}    -O2 ${HOPR_INSTRUCTION} -qopt-report0 -qopt-report-phase=vec")
+  SET (CMAKE_Fortran_FLAGS_PROFILE   "${CMAKE_Fortran_FLAGS} -p -O2 ${HOPR_INSTRUCTION} -qopt-report0 -qopt-report-phase=vec")
+  SET (CMAKE_Fortran_FLAGS_DEBUG     "${CMAKE_Fortran_FLAGS} -g -O0 -fpe0 -traceback -check all,noarg_temp_created,noformat,nooutput_conversion,pointer,uninit -init=snan -init=arrays")
   # add flags only for compiling not linking!
   SET (HOPR_COMPILE_FLAGS "-fpp -allow nofpp_comments -assume bscc")
 
 # Cray Compiler
 ELSEIF (CMAKE_Fortran_COMPILER_ID MATCHES "Cray")
   # set Flags
-  SET (CMAKE_Fortran_FLAGS         "${CMAKE_Fortran_FLAGS} -f free -s real64 -em -DCRAY")
-  SET (CMAKE_Fortran_FLAGS_RELEASE "${CMAKE_Fortran_FLAGS} -O2 -hfp3 -p . -rm")
-  SET (CMAKE_Fortran_FLAGS_PROFILE "${CMAKE_Fortran_FLAGS} -O2 -hfp3 -h profile_generate -p . -rm")
-  SET (CMAKE_Fortran_FLAGS_DEBUG   "${CMAKE_Fortran_FLAGS} -O0 -eD -rm")
+  IF (NOT DEFINED C_FLAGS_INITIALIZED )
+    SET (C_FLAGS_INITIALIZED "yes" CACHE INTERNAL "Flag if compiler flags are already initialized" )
+    SET (CMAKE_Fortran_FLAGS         "${CMAKE_Fortran_FLAGS} -f free -s real64 -em -DCRAY")
+  ENDIF()
+  SET (CMAKE_Fortran_FLAGS_RELEASE   "${CMAKE_Fortran_FLAGS} -O2 -hfp3 -p . -rm")
+  SET (CMAKE_Fortran_FLAGS_PROFILE   "${CMAKE_Fortran_FLAGS} -O2 -hfp3 -h profile_generate -p . -rm")
+  SET (CMAKE_Fortran_FLAGS_DEBUG     "${CMAKE_Fortran_FLAGS} -O0 -eD -rm")
   # add flags only for compiling not linking!
   SET (HOPR_COMPILE_FLAGS "-F")
 

--- a/CMakeListsMachine.txt
+++ b/CMakeListsMachine.txt
@@ -5,11 +5,48 @@
 MARK_AS_ADVANCED(FORCE CMAKE_HOSTNAME)
 SITE_NAME(CMAKE_HOSTNAME)
 
+# =========================================================================
+# Some clusters require setting the compilers by hand and invoking
+# ENABLE_LANGUAGE afterwards, which is required for
+# CMAKE_Fortran_COMPILER_ID that is used below
+# > This block must be called before ENABLE_LANGUAGE
+# =========================================================================
 # HLRS HAWK / SuperMUC
 IF ("${CMAKE_HOSTNAME}" MATCHES "login")
   SET(CMAKE_C_COMPILER       mpicc)
   SET(CMAKE_CXX_COMPILER     mpicxx)
   SET(CMAKE_Fortran_COMPILER mpif90) # mpif08 wrapper seems to have issue
+# IAG Prandtl
+ELSEIF("${CMAKE_HOSTNAME}" MATCHES "^prandtl")
+  SET(CMAKE_C_COMPILER       gcc)
+  SET(CMAKE_CXX_COMPILER     c++)
+  SET(CMAKE_Fortran_COMPILER gfortran)
+# IAG Grafik01/Grafik02
+ELSEIF ("${CMAKE_HOSTNAME}" MATCHES "^grafik0")
+  SET(CMAKE_C_COMPILER       gcc)
+  SET(CMAKE_CXX_COMPILER     c++)
+  SET(CMAKE_Fortran_COMPILER gfortran)
+ELSEIF ("${CMAKE_HOSTNAME}" MATCHES "^ilahead1")
+  SET(CMAKE_C_COMPILER       mpicc)
+  SET(CMAKE_CXX_COMPILER     mpicxx)
+  SET(CMAKE_Fortran_COMPILER mpif90) # mpif08 wrapper seems to have issue
+ELSEIF ("${CMAKE_HOSTNAME}" MATCHES "^xenon")
+  SET(CMAKE_C_COMPILER       mpicc)
+  SET(CMAKE_CXX_COMPILER     mpicxx)
+  SET(CMAKE_Fortran_COMPILER mpif90) # mpif08 wrapper seems to have issue
+ENDIF()
+
+# =========================================================================
+# After settings specific compilers, enable named languages for cmake
+# =========================================================================
+ENABLE_LANGUAGE(Fortran C)
+INCLUDE(GNUInstallDirs)
+
+# =========================================================================
+# Set machine-specific definitions and settings
+# =========================================================================
+# HLRS HAWK / SuperMUC
+IF ("${CMAKE_HOSTNAME}" MATCHES "login")
   MARK_AS_ADVANCED(FORCE C_PATH CXX_PATH Fortran_PATH)
 
   # HAWK and SuperMUC name their login nodes identically, so use OS distribution to identify
@@ -42,24 +79,15 @@ IF ("${CMAKE_HOSTNAME}" MATCHES "login")
 # IAG Prandtl
 ELSEIF("${CMAKE_HOSTNAME}" MATCHES "^prandtl")
   MESSAGE(STATUS "Compiling on Prandtl")
-  SET(CMAKE_C_COMPILER       gcc)
-  SET(CMAKE_CXX_COMPILER     c++)
-  SET(CMAKE_Fortran_COMPILER gfortran)
   MARK_AS_ADVANCED(FORCE C_PATH CXX_PATH Fortran_PATH)
 
 # IAG Grafik01/Grafik02
 ELSEIF ("${CMAKE_HOSTNAME}" MATCHES "^grafik0")
   MESSAGE(STATUS "Compiling on ${CMAKE_HOSTNAME}")
-  SET(CMAKE_C_COMPILER       gcc)
-  SET(CMAKE_CXX_COMPILER     c++)
-  SET(CMAKE_Fortran_COMPILER gfortran)
   MARK_AS_ADVANCED(FORCE C_PATH CXX_PATH Fortran_PATH)
 
 ELSEIF ("${CMAKE_HOSTNAME}" MATCHES "^ilahead1")
   MESSAGE(STATUS "Compiling on ILA cluster")
-  SET(CMAKE_C_COMPILER       mpicc)
-  SET(CMAKE_CXX_COMPILER     mpicxx)
-  SET(CMAKE_Fortran_COMPILER mpif90) # mpif08 wrapper seems to have issue
   MARK_AS_ADVANCED(FORCE C_PATH CXX_PATH Fortran_PATH)
   # Overwrite compiler target architecture
   IF (CMAKE_Fortran_COMPILER_ID MATCHES "GNU" OR CMAKE_Fortran_COMPILER_ID MATCHES "Flang")
@@ -70,12 +98,10 @@ ELSEIF ("${CMAKE_HOSTNAME}" MATCHES "^ilahead1")
 
 ELSEIF ("${CMAKE_HOSTNAME}" MATCHES "^xenon")
   MESSAGE(STATUS "Compiling on ILA student cluster")
-  SET(CMAKE_C_COMPILER       mpicc)
-  SET(CMAKE_CXX_COMPILER     mpicxx)
-  SET(CMAKE_Fortran_COMPILER mpif90) # mpif08 wrapper seems to have issue
   MARK_AS_ADVANCED(FORCE C_PATH CXX_PATH Fortran_PATH)
 
 ELSE()
+  MESSAGE(STATUS "Compiling on a generic machine")
   # Set compiler target architecture
   IF (CMAKE_Fortran_COMPILER_ID MATCHES "GNU" OR CMAKE_Fortran_COMPILER_ID MATCHES "Flang" )
     SET(HOPR_INSTRUCTION "-march=native")
@@ -84,12 +110,11 @@ ELSE()
   ENDIF()
 ENDIF()
 
+MESSAGE(STATUS "Compiling using [${HOPR_INSTRUCTION}] instruction")
 
 # =========================================================================
 # COMPILER FLAGS
 # =========================================================================
-
-ENABLE_LANGUAGE(Fortran C)
 
 # FFLAGS depend on the compiler
 GET_FILENAME_COMPONENT (Fortran_COMPILER_NAME ${CMAKE_Fortran_COMPILER} NAME)
@@ -99,7 +124,8 @@ IF (CMAKE_Fortran_COMPILER_ID MATCHES "GNU")
   # set Flags (disable lto type warnings due to false positives with MATMUL, which is a known bug)
   IF (NOT DEFINED C_FLAGS_INITIALIZED )
     SET (C_FLAGS_INITIALIZED "yes" CACHE INTERNAL "Flag if compiler flags are already initialized" )
-    SET (CMAKE_Fortran_FLAGS         "${CMAKE_Fortran_FLAGS} -fdefault-real-8 -fdefault-double-8 -fbackslash -ffree-line-length-0 -Wno-lto-type-mismatch -DGNU")
+    # initialize all variables as signalling NaNs to force the user to correctly initialize these data types
+    SET (CMAKE_Fortran_FLAGS         "${CMAKE_Fortran_FLAGS} -fdefault-real-8 -fdefault-double-8 -fbackslash -ffree-line-length-0 -finit-real=snan -finit-integer=snan -Wno-lto-type-mismatch -DGNU")
   ENDIF()
   SET (CMAKE_Fortran_FLAGS_RELEASE   "${CMAKE_Fortran_FLAGS}     -O3 ${HOPR_INSTRUCTION} -finline-functions -fstack-arrays")
   SET (CMAKE_Fortran_FLAGS_PROFILE   "${CMAKE_Fortran_FLAGS} -pg -O3 ${HOPR_INSTRUCTION} -finline-functions -fstack-arrays")
@@ -149,6 +175,19 @@ ELSEIF (CMAKE_Fortran_COMPILER_ID MATCHES "Cray")
 
 ELSE()
   MESSAGE(SEND_ERROR "Unknown compiler")
+ENDIF()
+
+# =========================================================================
+# Profile-Guided Optimization (PGO)
+# =========================================================================
+OPTION(USE_PGO "Enable profile-guided optimization (Only GNU Compiler supported)" OFF)
+IF (USE_PGO)
+  IF (CMAKE_Fortran_COMPILER_ID MATCHES "GNU")
+    SET(CMAKE_Fortran_FLAGS_RELEASE "${CMAKE_Fortran_FLAGS_RELEASE} -fprofile-use")
+    SET(CMAKE_Fortran_FLAGS_PROFILE "${CMAKE_Fortran_FLAGS_PROFILE} -fprofile-generate")
+  ELSE()
+    MESSAGE( SEND_ERROR "Profile-guided optimization (PGO) currently only supported for GNU compiler. Either set USE_GPO=OFF or use the GNU compiler." )
+  ENDIF()
 ENDIF()
 
 # Save the current compiler flags to the cache every time cmake configures the project.


### PR DESCRIPTION
This adds a number of recent fixes and improvements to hopr builds.

Bugfixes:
- Correct setting of machine-dependent flags by applying it before calling `ENABLE_LANGUAGE`
- Do not append `CMAKE_Fortran_FLAGS` each time `cmake` is run, preventing an ever growing argument list

Improvements:
- Link-time optimization (LTO)/Interprocedural optimization (IPO) support
- Profile-Guided Optimization (PGO) support (`USE_PGO`, defaults to `OFF`)
- Use GNU gold linker if supported for faster linking
- Optimized HDF5 build options
- Initialize variables as signalling NaN to detect code errors