### PR TITLE
Remove tabulators during the read-in of string variables

### DIFF
--- a/src/readin/readintools.f90
+++ b/src/readin/readintools.f90
@@ -540,6 +540,8 @@ DO WHILE(EOF.NE.IOSTAT_END)
       IF(LEN(CHAR(Separator)).EQ.0) Str1%Str=bStr
       ! Remove blanks
       Str1%Str=Replace(Str1%Str," ","",Every=.true.)
+      ! Remove tabulator
+      Str1%Str=Replace(Str1%Str,CHAR(9),"",Every=.true.)
       ! Replace brackets
       Str1%Str=Replace(Str1%Str,"(/"," ",Every=.true.)
       Str1%Str=Replace(Str1%Str,"/)"," ",Every=.true.)


### PR DESCRIPTION
Tabulators at the end of boundary names lead to problems during the mesh read-in PICLas