### PR TITLE
Bugfix in read-in of Gambit meshes: wrong length of integer read-in

### DIFF
--- a/src/readin/readin_gambit.f90
+++ b/src/readin/readin_gambit.f90
@@ -263,9 +263,10 @@ DO iFile=1,nMeshFiles
         BCalphaInd = BoundaryType(i,4)
         BCind      = i
         WRITE(*,*)'BC found: ',TRIM(strBC)
-        WRITE(*,*)'              -->  mapped to:',TRIM(BoundaryName(i))
+        WRITE(*,*)'              -->  mapped to: ', TRIM(BoundaryName(i))
         strBC=strBC(dummy1+LEN(TRIM(BoundaryName(i))):LEN(strBC))  ! First we need to cut off the boundary name...
-        READ(strBC,'(I8,I8,I8,I8)')dummy1,dummy2,nBCElems,dummy3  ! ...before we can read the number of BC elements
+        READ(strBC,'(I10,I10,I10,I10)')dummy1,nBCElems,dummy2,dummy3  ! ...before we can read the number of BC elements
+        WRITE(*,*)'                   nBCElems = ', nBCElems
         EXIT
       END IF
     END DO


### PR DESCRIPTION
The previous version worked only for boundaries with less than 10000 elements.