### PR TITLE
[improvement.hopr.version.h5] HOPR version in .h5 files (string and integer)

### DIFF
--- a/src/globals.f90
+++ b/src/globals.f90
@@ -54,10 +54,11 @@ INTEGER, PARAMETER          :: UNIT_logOut = 100          ! For logging
 CHARACTER(LEN=255)          :: ProjectName                ! necessary data for in/output and name used to generate filenames from
 LOGICAL                     :: Logging                    ! Set .TRUE. to activate logging function for each processor
 
-INTEGER,PARAMETER           :: MajorVersion = 1                     !> FileVersion number saved in each hdf5 file with hdf5 header
-INTEGER,PARAMETER           :: MinorVersion = 0                     !> FileVersion number saved in each hdf5 file with hdf5 header
-INTEGER,PARAMETER           :: PatchVersion = 0                     !> FileVersion number saved in each hdf5 file with hdf5 header
-REAL,PARAMETER              :: FileVersion  = REAL(MajorVersion,8)+REAL(MinorVersion,8)/10.+REAL(PatchVersion,8)/100. !> FileVersion
+INTEGER,PARAMETER           :: MajorVersion = 1           !> HoprVersion saved in each hdf5 file with hdf5 header
+INTEGER,PARAMETER           :: MinorVersion = 0           !> HoprVersion saved in each hdf5 file with hdf5 header
+INTEGER,PARAMETER           :: PatchVersion = 0           !> HoprVersion saved in each hdf5 file with hdf5 header
+INTEGER,PARAMETER           :: HoprVersionInt = PatchVersion+MinorVersion*100+MajorVersion*10000 !> Hopr version number saved in each hdf5 file with hdf5 header
+CHARACTER(LEN=10)           :: HoprVersionStr             !> Hopr version string saved in each hdf5 file with hdf5 header
 
 
 

--- a/src/output/output_hdf5.f90
+++ b/src/output/output_hdf5.f90
@@ -73,7 +73,6 @@ INTEGER                        :: locnSides
 INTEGER                        :: iNode,i,iMortar
 LOGICAL                        :: found
 CHARACTER(LEN=26)              :: ElemTypeName(1:11)
-CHARACTER(LEN=10)              :: hilf
 !===================================================================================================================================
 WRITE(UNIT_stdOut,'(132("~"))')
 CALL Timer(.TRUE.)
@@ -274,9 +273,9 @@ CALL getMeshInfo() !allocates and fills ElemInfo,SideInfo,NodeInfo,NodeCoords
 CALL OpenHDF5File(FileString,create=.TRUE.)  
 
 !attributes 
-WRITE(UNIT=hilf,FMT='(I0,A1,I0,A1,I0)') MajorVersion,".",MinorVersion,".",PatchVersion
-CALL WriteAttribute(File_ID,'VersionStr',1,StrScalar=TRIM(hilf))
-CALL WriteAttribute(File_ID,'Version',1,RealScalar=FileVersion)
+WRITE(UNIT=HoprVersionStr,FMT='(I0,A1,I0,A1,I0)') MajorVersion,".",MinorVersion,".",PatchVersion
+CALL WriteAttribute(File_ID,'HoprVersion',1,StrScalar=TRIM(HoprVersionStr))
+CALL WriteAttribute(File_ID,'HoprVersionInt',1,IntScalar=HoprVersionInt)
 CALL WriteAttribute(File_ID,'Ngeo',1,IntScalar=N)
 CALL WriteAttribute(File_ID,'nElems',1,IntScalar=nElems)
 CALL WriteAttribute(File_ID,'nSides',1,IntScalar=nSides)


### PR DESCRIPTION
Removed floating point hopr version and replaced it with 6-digit integer that combines MajorVersion/MinorVersion/PatchVersion.