### PR TITLE
Use correct BC_Alpha for zCorrection

### DIFF
--- a/src/mesh/mesh.f90
+++ b/src/mesh/mesh.f90
@@ -79,16 +79,16 @@ IF(.NOT.OutputInitDone)THEN
 END IF
 
 ! Curved
-useCurveds      = GETLOGICAL('useCurveds','.FALSE.')   ! Use / reconstruct spline boundaries
+useCurveds = GETLOGICAL('useCurveds','.FALSE.')   ! Use / reconstruct spline boundaries
 IF(useCurveds)THEN
   N = GETINT('BoundaryOrder','4')-1     ! Get spline order / type
 ELSE
-  N=1
+  N = 1
 END IF
 
 ! Mesh mode: 0=HDF5 input, 1=Internal cartesian, 2=Gambit, 3=CGNS, 4=ANSA, 5=GMSH
-MeshMode=GETINT('Mode')
-meshIsAlreadyCurved=.FALSE.
+MeshMode = GETINT('Mode')
+meshIsAlreadyCurved = .FALSE.
 IF (MeshMode .EQ. 1) THEN
   ! ---------- INTERNAL CARTESIAN MESH ---------------------------------------------------------------------------------------------
   IF(useCurveds) THEN
@@ -97,39 +97,39 @@ IF (MeshMode .EQ. 1) THEN
     InnerElemStretch = .FALSE.
   END IF
   IF(InnerElemStretch) MeshIsAlreadyCurved=.TRUE.
-  nZones  =GETINT('nZones')
+  nZones = GETINT('nZones')
   ALLOCATE(CartMeshes(nZones))
   DO i=1,nZones
     ALLOCATE(CartMeshes(i)%CM)
-    buf=GETREALARRAY('Corner',24)  ! Corner nodes of zone
+    buf = GETREALARRAY('Corner',24)  ! Corner nodes of zone
     DO j=1,8
-      CartMeshes(i)%CM%Corner(:,j)=buf((j-1)*3+1:j*3)
+      CartMeshes(i)%CM%Corner(:,j) = buf((j-1)*3+1:j*3)
     END DO
-    CartMeshes(i)%CM%BCIndex =GETINTARRAY('BCIndex',6)  ! Boundary type
-    CartMeshes(i)%CM%nElems  =GETINTARRAY('nElems',3)   ! No of elems in each direction
-    CartMeshes(i)%CM%l0      =GETREALARRAY('l0',3,'0.,0.,0.') ! first length (+/-) = direction
-    CartMeshes(i)%CM%factor  =GETREALARRAY('factor',3,'0.,0.,0.') ! stretch factor (+/-) = direction
-    CartMeshes(i)%CM%ElemType=GETINT('elemtype') ! Element type
-    CartMeshes(i)%CM%meshTemplate=GETINT('meshTemplate','1') ! Element type
+    CartMeshes(i)%CM%BCIndex       = GETINTARRAY('BCIndex',6)            ! Boundary type
+    CartMeshes(i)%CM%nElems        = GETINTARRAY('nElems',3)             ! No of elems in each direction
+    CartMeshes(i)%CM%l0            = GETREALARRAY('l0',3,'0.,0.,0.')     ! first length (+/-)   = direction
+    CartMeshes(i)%CM%factor        = GETREALARRAY('factor',3,'0.,0.,0.') ! stretch factor (+/-) = direction
+    CartMeshes(i)%CM%ElemType      = GETINT('elemtype')                  ! Element type
+    CartMeshes(i)%CM%meshTemplate  = GETINT('meshTemplate','1')          ! Element type
   END DO
 ELSEIF (MeshMode .EQ. 11) THEN
   ! ---------- INTERNAL 1 BLOCK CURVED CARTESIAN MESH -----------------------------------------------------------------
-  nZones  =GETINT('nZones')
-  stretchType = GETINTARRAY('stretchType',3,'0,0,0')
-  fac = GETREALARRAY('fac',3,'1.,1.,1.')
+  nZones         = GETINT('nZones')
+  stretchType    = GETINTARRAY('stretchType',3,'0,0,0')
+  fac            = GETREALARRAY('fac',3,'1.,1.,1.')
   WRITE(DefStr,'(E21.11,A1,E21.11,A1,E21.11)')fac(1),',',fac(2),',',fac(3)
-  fac2 = GETREALARRAY('fac2',3,TRIM(DefStr))
-  DxmaxToDxmin = GETREALARRAY('DxmaxToDxmin',3,'1.,1.,1.')
+  fac2           = GETREALARRAY('fac2',3,TRIM(DefStr))
+  DxmaxToDxmin   = GETREALARRAY('DxmaxToDxmin',3,'1.,1.,1.')
   !read in Mesh Parameters
   CurvedMeshType = GETINT('Meshtype','1')
-  BCIndex =GETINTARRAY('BCIndex',6)  ! Boundary type
-  nElems  =GETINTARRAY('nElems',3)   ! No of elems in each direction
+  BCIndex        = GETINTARRAY('BCIndex',6)  ! Boundary type
+  nElems         = GETINTARRAY('nElems',3)   ! No of elems in each direction
   ! rescale the factor if innercell stretching is used, so the same factor can be supplied
   ! in parameter file for cell and innercell stretching
   DO i=1,3
     IF(stretchType(i).EQ.6) THEN
-      fac(i)=fac(i)**(nElems(i))
-      fac2(i)=fac2(i)**(nElems(i))
+      fac(i)  = fac( i)**(nElems(i))
+      fac2(i) = fac2(i)**(nElems(i))
     END IF
   END DO
   SELECT CASE(CurvedmeshType)
@@ -169,41 +169,41 @@ ELSEIF (MeshMode .EQ. 11) THEN
       R_0   = GETREAL('R_0','0.1') ! height of bump
       R_INF = GETREAL('R_INF','1.') ! length of bump
     END SELECT ! WhichMapping
-  END SELECT !MEshType
+  END SELECT !MeshType
   meshisAlreadyCurved=.TRUE.
 ELSE
   ! ---------- EXTERNAL MESH -------------------------------------------------------------------------------------------------------
   nMeshFiles=1
   SELECT CASE(MeshMode)
   CASE(-1,0)   ! HDF5 input file (-1: old for conversion)
-    nMeshFiles=GETINT('nMeshFiles','1') ! Number of mesh files: each mesh file = one zone
-    meshIsAlreadyCurved=.TRUE.
-  CASE(2)   ! Gambit
-    nMeshFiles=GETINT('nMeshFiles','1') ! Number of mesh files: each mesh file = one zone
-    useBinary =GETLOGICAL('useBinary','.FALSE.')  ! Read binary mesh file (.halo files) instead of ASCII
-  CASE(3)   ! CGNS mesh
+    nMeshFiles = GETINT('nMeshFiles','1')           ! Number of mesh files: each mesh file = one zone
+    meshIsAlreadyCurved = .TRUE.
+  CASE(2)      ! Gambit
+    nMeshFiles = GETINT('nMeshFiles','1')           ! Number of mesh files: each mesh file = one zone
+    useBinary  = GETLOGICAL('useBinary','.FALSE.')  ! Read binary mesh file (.halo files) instead of ASCII
+  CASE(3)      ! CGNS mesh
     meshIsAlreadyCurved = GETLOGICAL('meshIsAlreadyCurved','.FALSE.')  ! build curveds by agglomeration (only block structured)
-    nskipZ=GETINT('nskipZ','1') !skip every nskip point (=1, nothing is skipped)
+    nskipZ = GETINT('nskipZ','1')                   ! skip every nskip point (=1, nothing is skipped)
     WRITE(DefStr,*) N
-    NBlock=GETINT('NBlock',TRIM(DefStr)) !initial polynomial degree of block structured mesh
-    nskip=GETINT('nskip','1') !skip every nskip point (=1, nothing is skipped)
+    NBlock = GETINT('NBlock',TRIM(DefStr))          ! initial polynomial degree of block structured mesh
+    nskip  = GETINT('nskip','1')                    ! skip every nskip point (=1, nothing is skipped)
     !nSkip=1 ! TODO: integrate into reader or remove
-    nMeshFiles=GETINT('nMeshFiles','1') ! Number of mesh files: each mesh file = one zone
-    BugFix_ANSA_CGNS=GETLOGICAL('BugFix_ANSA_CGNS','.FALSE.')
-  CASE(5)   ! GMSH file
-    meshIsAlreadyCurved=.TRUE.
+    nMeshFiles       = GETINT('nMeshFiles','1')     ! Number of mesh files: each mesh file = one zone
+    BugFix_ANSA_CGNS = GETLOGICAL('BugFix_ANSA_CGNS','.FALSE.')
+  CASE(5)       ! GMSH file
+    meshIsAlreadyCurved = .TRUE.
   END SELECT
   ALLOCATE(MeshFileName(nMeshFiles))
   DO i=1,nMeshFiles
-    MeshFileName(i)=GETSTR('FileName') ! Read file name
+    MeshFileName(i) = GETSTR('FileName') ! Read file name
   END DO
 END IF
 
 ! Geometry
-postScale=GETLOGICAL('postScaleMesh','.FALSE.') ! apply scaling either after readin or before output
-MeshScale=GETREAL('meshScale','1.0')           ! scaling factor applied to node coordinates during read in
-doScale  = (ABS(MeshScale-1.).GT.PP_RealTolerance)
-SpaceQuandt=GETREAL('SpaceQuandt','0.1')
+postScale   = GETLOGICAL('postScaleMesh','.FALSE.') ! apply scaling either after readin or before output
+MeshScale   = GETREAL('meshScale','1.0')            ! scaling factor applied to node coordinates during read in
+doScale     = (ABS(MeshScale-1.).GT.PP_RealTolerance)
+SpaceQuandt = GETREAL('SpaceQuandt','0.1')
 
 ! Curved
 IF(useCurveds) THEN
@@ -221,28 +221,28 @@ IF(useCurveds) THEN
       SELECT CASE(normalsType)
       CASE(1) ! normals by reconstruction
       CASE(2) ! CAD normals
-        NormalVectFile=GETSTR('NormalVectFile')
-        minNormalAngle=GETREAL('minNormalAngle','2.')
-        minNormalAngle=COS(minNormalAngle*PI/180.)
+        NormalVectFile = GETSTR('NormalVectFile')
+        minNormalAngle = GETREAL('minNormalAngle','2.')
+        minNormalAngle = COS(minNormalAngle*PI/180.)
       CASE(3) ! exact normals
-        N=3
-        tmpInt=GETINT('nExactNormals')
+        N      = 3
+        tmpInt = GETINT('nExactNormals')
         ALLOCATE(ExactNormals(tmpInt*2))
-        ExactNormals=GETINTARRAY('exactNormals',tmpInt*2) !(Curvedindex,exactnormaltype,...)
+        ExactNormals = GETINTARRAY('exactNormals',tmpInt*2) !(Curvedindex,exactnormaltype,...)
         ! >0 if an analytical normal can be used (see curved.f90,exactNormals)
       CASE DEFAULT
         CALL abort(__STAMP__,&
           'No normal type specified.')
       END SELECT
     CASE(3) ! refined surface elements (only ANSA readin)
-      SplitElemFile=GETSTR('SplitElemFile')
+      SplitElemFile = GETSTR('SplitElemFile')
       IF(INDEX(TRIM(SplitElemFile),'.cgns').NE.0)THEN
-        SplitMeshMode=4
+        SplitMeshMode = 4
       ELSE
-        SplitMeshMode=3
+        SplitMeshMode = 3
       END IF
     CASE(4) ! ICEM spectral elements
-      SpecElemFile=GETSTR('specelemfile')
+      SpecElemFile = GETSTR('specelemfile')
     CASE DEFAULT
       CALL abort(__STAMP__,&
         'Specified curving method does not exist. =1: NormalVectors, =3: SplitElemFile, =4: SpecElemFile')
@@ -273,8 +273,8 @@ IF(nUserDefinedBoundaries .GT. 0)THEN
   ALLOCATE(BoundaryName(nUserDefinedBoundaries))
   ALLOCATE(BoundaryType(nUserDefinedBoundaries,4))
   DO i=1,nUserDefinedBoundaries
-    BoundaryName(i)  =GETSTR('BoundaryName')
-    BoundaryType(i,:)=GETINTARRAY('BoundaryType',4)
+    BoundaryName(i)   = GETSTR('BoundaryName')
+    BoundaryType(i,:) = GETINTARRAY('BoundaryType',4)
   END DO
 END IF
 
@@ -297,12 +297,12 @@ END IF
 IF((MeshMode .EQ. 6)) MeshDim=2
 
 IF(MeshDim .EQ. 2)THEN
-  zLength=GETREAL('zLength')
-  nElemsZ=GETINT('nElemsZ')
-  dz      = zLength/DBLE(nElemsZ)
-  zLength = dz*DBLE(nElemsZ)
-  lowerZ_BC=GETINTARRAY('lowerZ_BC',4)
-  upperZ_BC=GETINTARRAY('upperZ_BC',4)
+  zLength   = GETREAL('zLength')
+  nElemsZ   = GETINT('nElemsZ')
+  dz        = zLength/DBLE(nElemsZ)
+  zLength   = dz*DBLE(nElemsZ)
+  lowerZ_BC = GETINTARRAY('lowerZ_BC',4)
+  upperZ_BC = GETINTARRAY('upperZ_BC',4)
   ALLOCATE(BC_NameDummy(nUserDefinedBoundaries))
   ALLOCATE(BC_TypeDummy(nUserDefinedBoundaries,4))
   BC_NameDummy=BoundaryName
@@ -312,29 +312,29 @@ IF(MeshDim .EQ. 2)THEN
   nUserDefinedBoundaries=nUserDefinedBoundaries+2
   ALLOCATE(BoundaryName(nUserDefinedBoundaries))
   ALLOCATE(BoundaryType(nUserDefinedBoundaries,4))
-  BoundaryName(1:nUserDefinedBoundaries-2    )=BC_NameDummy(:)
-  BoundaryType(1:nUserDefinedBoundaries-2,1:4)=BC_TypeDummy(:,1:4)
-  BoundaryName(nUserDefinedBoundaries-1      )='LowerZ_BC'
-  BoundaryType(nUserDefinedBoundaries-1,1:4  )=lowerZ_BC
-  BoundaryName(nUserDefinedBoundaries        )='UpperZ_BC'
-  BoundaryType(nUserDefinedBoundaries  ,1:4  )=upperZ_BC
-  lowerZ_BC_Ind=nUserDefinedBoundaries-1
-  upperZ_BC_Ind=nUserDefinedBoundaries
+  BoundaryName(1:nUserDefinedBoundaries-2    ) = BC_NameDummy(:)
+  BoundaryType(1:nUserDefinedBoundaries-2,1:4) = BC_TypeDummy(:,1:4)
+  BoundaryName(nUserDefinedBoundaries-1      ) = 'LowerZ_BC'
+  BoundaryType(nUserDefinedBoundaries-1,1:4  ) = lowerZ_BC
+  BoundaryName(nUserDefinedBoundaries        ) = 'UpperZ_BC'
+  BoundaryType(nUserDefinedBoundaries  ,1:4  ) = upperZ_BC
+  lowerZ_BC_Ind = nUserDefinedBoundaries-1
+  upperZ_BC_Ind = nUserDefinedBoundaries
   DEALLOCATE(BC_NameDummy,BC_TypeDummy)
 END IF  ! MeshDim=2
 
 ! zcorrection
-doZcorrection=GETLOGICAL('doZcorrection','.FALSE.')
-OrientZ=GETLOGICAL('OrientZ','.FALSE.')
+doZcorrection = GETLOGICAL('doZcorrection','.FALSE.')
+OrientZ       = GETLOGICAL('OrientZ','.FALSE.')
 IF(doZcorrection)THEN
-  zLength=GETREAL('zLength')
-  nElemsZ=GETINT('nElemsZ')
-  zstart=GETREAL('zstart')
-  zPeriodic=GETLOGICAL('zPeriodic','.FALSE.')
+  zLength   = GETREAL('zLength')
+  nElemsZ   = GETINT('nElemsZ')
+  zstart    = GETREAL('zstart')
+  zPeriodic = GETLOGICAL('zPeriodic','.FALSE.')
 END IF
 !splitting of elements
-SplitToHex=GETLOGICAL('SplitToHex','.FALSE.')   ! split all elements to hexa
-nFineHexa=GETINT('nFineHexa','1')               ! split all hexa by a factor
+SplitToHex = GETLOGICAL('SplitToHex','.FALSE.')   ! split all elements to hexa
+nFineHexa  = GETINT('nFineHexa','1')               ! split all hexa by a factor
 
 nSplitBoxes=CNTSTR('SplitBox','0')
 ALLOCATE(SplitBoxes(3,2,nSplitBoxes))
@@ -349,13 +349,13 @@ doRebuildMortarGeometry=GETLOGICAL('doRebuildMortarGeometry','.TRUE.')
 
 meshPostDeform=GETINT('MeshPostDeform','0')
 IF(meshPostDeform.GT.0) THEN
-  PostDeform_useGL=GETLOGICAL('PostDeform_useGL','.TRUE.')
-  PostDeform_R0=GETREAL('PostDeform_R0','1.')
-  PostDeform_Lz=GETREAL('PostDeform_Lz','1.')
-  PostDeform_sq=GETREAL('PostDeform_sq','0.')
-  PostDeform_Rtorus=GETREAL('PostDeform_Rtorus','-1.') !from cyl-> torus
+  PostDeform_useGL  = GETLOGICAL('PostDeform_useGL','.TRUE.')
+  PostDeform_R0     = GETREAL('PostDeform_R0','1.')
+  PostDeform_Lz     = GETREAL('PostDeform_Lz','1.')
+  PostDeform_sq     = GETREAL('PostDeform_sq','0.')
+  PostDeform_Rtorus = GETREAL('PostDeform_Rtorus','-1.') !from cyl-> torus
 
-  postConnect=GETINT('postConnect','0')
+  postConnect       = GETINT('postConnect','0')
   IF(postConnect.EQ.3)THEN
     IF(nVV.GT.0)THEN
       tmpInt=  CNTSTR('postVV','0')
@@ -680,14 +680,14 @@ END IF
 
 IF(MeshPostDeform.NE.0)THEN
   CALL PostDeform()
-  
+
   SELECT CASE(postConnect)
   CASE(0) !do nothing
   CASE(1) !reconnect all sides
     CALL Connect(reconnect=.TRUE.,deletePeriodic=.FALSE.)                           ! Create connection between elements
   CASE(2) !reconnect all sides, delete periodic connections (sides on top by postdeform)
-    CALL Connect(reconnect=.TRUE.,deletePeriodic=.TRUE.)                           ! Create connection between elements
-  CASE(3) !reconnect all sides, overwrite periodic connections 
+    CALL Connect(reconnect=.TRUE.,deletePeriodic=.TRUE.)                            ! Create connection between elements
+  CASE(3) !reconnect all sides, overwrite periodic connections
     DO i=1,nVV
       vv(:,i)=postVV(:,i)
     END DO
@@ -778,9 +778,9 @@ DO WHILE(ASSOCIATED(Elem))
     ConnectionSide = .TRUE.
     UpperBCSide    = .TRUE.
     DO iNode=1,Side%nNodes
-      IF(ABS(Side%Node(iNode)%np%x(3) - zMin) .GT. (PP_MeshTolerance*SpaceQuandt)) LowerBCSide    = .FALSE.
+      IF(ABS(Side%Node(iNode)%np%x(3) - zMin)           .GT. (PP_MeshTolerance*SpaceQuandt)) LowerBCSide    = .FALSE.
       IF(ABS(Side%Node(iNode)%np%x(3) - zMin - zLength) .GT. (PP_MeshTolerance*SpaceQuandt)) UpperBCSide    = .FALSE.
-      IF(ABS(Side%Node(iNode)%np%x(3) - zMin - zPos).GT.(PP_MeshTolerance*SpaceQuandt)) ConnectionSide = .FALSE.
+      IF(ABS(Side%Node(iNode)%np%x(3) - zMin - zPos)    .GT.(PP_MeshTolerance*SpaceQuandt))  ConnectionSide = .FALSE.
     END DO
     IF(.NOT.(LowerBCSide.OR.UpperBCSide.OR.ConnectionSide))THEN
       Side=>Side%nextElemSide

--- a/src/mesh/zcorrection.f90
+++ b/src/mesh/zcorrection.f90
@@ -12,7 +12,7 @@
 ! Copyright (C) 2017 Claus-Dieter Munz <munz@iag.uni-stuttgart.de>
 ! This file is part of HOPR, a software for the generation of high-order meshes.
 !
-! HOPR is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License 
+! HOPR is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
 ! as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
 !
 ! HOPR is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
@@ -31,15 +31,15 @@ USE MOD_Globals
 IMPLICIT NONE
 PRIVATE
 !-----------------------------------------------------------------------------------------------------------------------------------
-! GLOBAL VARIABLES 
+! GLOBAL VARIABLES
 !-----------------------------------------------------------------------------------------------------------------------------------
 ! Private Part ---------------------------------------------------------------------------------------------------------------------
 ! Public Part ----------------------------------------------------------------------------------------------------------------------
-INTERFACE OrientElemsToZ 
+INTERFACE OrientElemsToZ
   MODULE PROCEDURE OrientElemsToZ
 END INTERFACE
 
-INTERFACE zcorrection 
+INTERFACE zcorrection
   MODULE PROCEDURE zcorrection
 END INTERFACE
 
@@ -47,9 +47,10 @@ PUBLIC::OrientElemsToZ,zcorrection
 !===================================================================================================================================
 
 CONTAINS
+
 SUBROUTINE OrientElemsToZ()
 !===================================================================================================================================
-! called when using zcorrection, orientates zeta  of element with z direction 
+! called when using zcorrection, orientates zeta  of element with z direction
 !===================================================================================================================================
 ! MODULES
 USE MOD_Mesh_Vars,ONLY:FirstElem,tElem,tNodePtr,tSidePtr,tSide
@@ -141,7 +142,7 @@ DO WHILE(ASSOCIATED(Elem))
   DO whichdir=1,3
     scalprod=SUM(dir(whichdir,:)*(/0.,0.,1./))
     IF(ABS(scalprod).GT.0.95) THEN
-      found=.TRUE.     
+      found=.TRUE.
       EXIT
     END IF
   END DO
@@ -165,7 +166,7 @@ DO WHILE(ASSOCIATED(Elem))
   DO iSide=1,6
     NULLIFY(Sides(iSide)%sp%nextElemSide)
   END DO
-  !Reassign Side pointers 
+  !Reassign Side pointers
   im=MapSides(1,switch,whichdir)
   Elem%firstSide=>Sides(im)%sp
   Side=>Elem%firstSide
@@ -257,17 +258,17 @@ IMPLICIT NONE
 ! OUTPUT VARIABLES
 !-----------------------------------------------------------------------------------------------------------------------------------
 ! LOCAL VARIABLES
-TYPE(tElem),POINTER         :: Elem,lastElem  ! ?
-TYPE(tSide),POINTER         :: Side,zminusSide,zplusSide  ! ?
-INTEGER                     :: whichdirArr(nMeshElems),orientArr(nMeshElems)  ! ?
-INTEGER                     :: Map(4,2),SideMap(2)  ! ?
-INTEGER                     :: p,q,l,l1,l2,iSide  ! ?
-INTEGER                     :: switch, switch2, zcounter, whichdir  ! ?
-REAL                        :: scalprod,dir(3,3), displ1(3,0:N), displ2(3,0:N), displ(3,0:N)  ! ?
-LOGICAL                     :: firstLayer  ! ?
-LOGICAL                     :: dominant  ! ?
-LOGICAL                     :: found     ! ?
-INTEGER                     :: iNode,fNode,nPeriodicSides  ! ?
+TYPE(tElem),POINTER         :: Elem,lastElem                                                 ! ?
+TYPE(tSide),POINTER         :: Side,zminusSide,zplusSide                                     ! ?
+INTEGER                     :: whichdirArr(nMeshElems),orientArr(nMeshElems)                 ! ?
+INTEGER                     :: Map(4,2),SideMap(2)                                           ! ?
+INTEGER                     :: p,q,l,l1,l2,iSide                                             ! ?
+INTEGER                     :: switch, switch2, zcounter, whichdir                           ! ?
+REAL                        :: scalprod,dir(3,3), displ1(3,0:N), displ2(3,0:N), displ(3,0:N) ! ?
+LOGICAL                     :: firstLayer                                                    ! ?
+LOGICAL                     :: dominant                                                      ! ?
+LOGICAL                     :: found                                                         ! ?
+INTEGER                     :: iNode,fNode,nPeriodicSides                                    ! ?
 !===================================================================================================================================
 WRITE(UNIT_stdOut,'(A)') ' PERFORMING Z CORRECTION...'
 CALL Timer(.TRUE.)
@@ -359,7 +360,7 @@ DO WHILE(ASSOCIATED(lastElem))
     Side => oppSide(Side)
   END DO !while not associated BC
   zminusSide=>Side
-  ! now we are at a side and the corresponding cell at z=zmin, start the correction from here  
+  ! now we are at a side and the corresponding cell at z=zmin, start the correction from here
   ! correction  of nodes all elements in opposite direction (+z)
   Side => oppSide(Side)
   Elem=>Side%Elem
@@ -368,8 +369,8 @@ DO WHILE(ASSOCIATED(lastElem))
   DO  !correct element
     whichdir=whichdirArr(Elem%ind)
     switch=orientArr(Elem%ind)
-   
-    !Map for corner nodes (CGNS standard) 
+
+    !Map for corner nodes (CGNS standard)
     SELECT CASE(whichdir)
     CASE(1) !dir1 is periodic direction
       Map(:,1)=(/1,5,8,4/) !ximinus
@@ -421,7 +422,7 @@ DO WHILE(ASSOCIATED(lastElem))
 
     !curved
     IF(ASSOCIATED(Elem%CurvedNode))THEN
-      IF(switch.EQ.1)THEN !scalprod is positive 
+      IF(switch.EQ.1)THEN !scalprod is positive
         l1=1; l2=N;   iSide=0; displ=displ1
       ELSE !scalprod<0
         l1=0; l2=N-1; iSide=N; displ=displ2
@@ -436,7 +437,7 @@ DO WHILE(ASSOCIATED(lastElem))
             END IF
           CASE(2)
             IF(Elem%curvedNode(HexaMapInv(p,l,q))%np%tmp .NE. 0) THEN
-               Elem%curvedNode(HexaMapInv(p,l,q))%np%x=Elem%curvedNode(HexaMapInv(p,iSide,q))%np%x + displ(:,l) 
+               Elem%curvedNode(HexaMapInv(p,l,q))%np%x=Elem%curvedNode(HexaMapInv(p,iSide,q))%np%x + displ(:,l)
                Elem%curvedNode(HexaMapInv(p,l,q))%np%tmp=0
             END IF
           CASE(3)
@@ -502,13 +503,14 @@ DO WHILE(ASSOCIATED(lastElem))
       Side => oppSide(Side)
       zcounter=zcounter+1
     END IF
-     
+
   END DO !correct element
   lastElem=>lastElem%nextElem
 END DO
 IF(zPeriodic) WRITE(UNIT_StdOut,*)'Number of Periodic sides built:' ,nPeriodicSides
 CALL Timer(.FALSE.)
 END SUBROUTINE zcorrection
+
 
 FUNCTION oppSide(Side)
 !===================================================================================================================================
@@ -535,7 +537,6 @@ DO WHILE(ASSOCIATED(OppSide))
   IF(OppSide%LocSide .EQ. oppSideMap(Side%LocSide)) EXIT
   OppSide=>OppSide%nextElemSide
 END DO
-END FUNCTION oppSide 
-
+END FUNCTION oppSide
 
 END MODULE MOD_zcorrection

--- a/src/output/output_hdf5.f90
+++ b/src/output/output_hdf5.f90
@@ -13,7 +13,7 @@
 ! Copyright (C) 2017 Claus-Dieter Munz <munz@iag.uni-stuttgart.de>
 ! This file is part of HOPR, a software for the generation of high-order meshes.
 !
-! HOPR is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License 
+! HOPR is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
 ! as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
 !
 ! HOPR is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
@@ -32,7 +32,7 @@ USE MOD_IO_HDF5
 IMPLICIT NONE
 PRIVATE
 !-----------------------------------------------------------------------------------------------------------------------------------
-! GLOBAL VARIABLES 
+! GLOBAL VARIABLES
 !-----------------------------------------------------------------------------------------------------------------------------------
 
 INTERFACE WriteMeshToHDF5
@@ -133,8 +133,8 @@ DO WHILE(ASSOCIATED(Elem))
       IF(Side%MortarType.EQ.0)THEN
         nSideIDs=nSideIDs+1
         Side%ind=-88888
-        IF(ASSOCIATED(Side%connection))THEN      
-          Side%connection%ind = -88888 ! count inner and periodic sides only once 
+        IF(ASSOCIATED(Side%connection))THEN
+          Side%connection%ind = -88888 ! count inner and periodic sides only once
         END IF
       ELSEIF(Side%MortarType.GT.0)THEN
         locnSides = locnSides + Side%nMortars
@@ -144,7 +144,7 @@ DO WHILE(ASSOCIATED(Elem))
           IF(Side%MortarSide(iMortar)%sp%ind.EQ.0)THEN
             nSideIDs=nSideIDs+1
             Side%MortarSide(iMortar)%sp%ind=-88888
-          END IF 
+          END IF
         END DO !iMortar
       ELSE
         nSideIDs=nSideIDs+1
@@ -179,7 +179,7 @@ SideID=0
 NodeID=0
 Elem=>firstElem
 DO WHILE(ASSOCIATED(Elem))
-  ElemID=ElemID+1 
+  ElemID=ElemID+1
   Elem%ind=ElemID
   ElemBarycenters(ElemID,:)=0.
   DO i=1,Elem%nNodes
@@ -197,12 +197,12 @@ DO WHILE(ASSOCIATED(Elem))
 
   Side=>Elem%firstSide
   DO WHILE(ASSOCIATED(Side))
-    IF(side%ind.EQ.-88888) THEN  ! assign side ID 
+    IF(side%ind.EQ.-88888) THEN  ! assign side ID
       IF(Side%MortarType.EQ.0)THEN
         SideID=SideID+1
         Side%ind=SideID
-        IF(ASSOCIATED(Side%connection))THEN      
-          IF(Side%connection%ind.EQ.-88888) Side%connection%ind=SideID ! count inner and periodic sides only once 
+        IF(ASSOCIATED(Side%connection))THEN
+          IF(Side%connection%ind.EQ.-88888) Side%connection%ind=SideID ! count inner and periodic sides only once
         END IF
       ELSEIF(Side%MortarType.GT.0)THEN
         SideID=SideID+1
@@ -211,7 +211,7 @@ DO WHILE(ASSOCIATED(Elem))
           IF(Side%MortarSide(iMortar)%sp%ind.EQ.-88888)THEN
             SideID=SideID+1
             Side%MortarSide(iMortar)%sp%ind=SideID
-          END IF 
+          END IF
         END DO !iMortar
       ELSE
         SideID=SideID+1
@@ -231,7 +231,7 @@ IF(ElemID.NE.nElems) CALL abort(__STAMP__,&
                      'Sanity check: max(elemID <> nElems!')
 
 
-!set Side Flip 
+!set Side Flip
 Elem=>firstElem
 DO WHILE(ASSOCIATED(Elem))
   Side=>Elem%firstSide
@@ -256,7 +256,7 @@ DO WHILE(ASSOCIATED(Elem))
           found=.TRUE.
           EXIT
         END IF
-      END DO 
+      END DO
       IF(.NOT.found) STOP 'Flip not found'
       Side%flip=iNode
       IF(.NOT.ASSOCIATED(Side%connection)) CALL ABORT(__STAMP__, &
@@ -271,9 +271,9 @@ END DO
 CALL getMeshInfo() !allocates and fills ElemInfo,SideInfo,NodeInfo,NodeCoords
 
 ! Create the file
-CALL OpenHDF5File(FileString,create=.TRUE.)  
+CALL OpenHDF5File(FileString,create=.TRUE.)
 
-!attributes 
+!attributes
 WRITE(UNIT=hilf,FMT='(I0,A1,I0,A1,I0)') MajorVersion,".",MinorVersion,".",PatchVersion
 CALL WriteAttribute(File_ID,'VersionStr',1,StrScalar=TRIM(hilf))
 CALL WriteAttribute(File_ID,'Version',1,RealScalar=FileVersion)
@@ -284,11 +284,11 @@ CALL WriteAttribute(File_ID,'nNodes',1,IntScalar=nNodes)
 CALL WriteAttribute(File_ID,'nUniqueSides',1,IntScalar=nSideIDs)
 CALL WriteAttribute(File_ID,'nUniqueNodes',1,IntScalar=nNodeIDs)
 
-!WRITE ElemInfo,into (1,nElems)  
+!WRITE ElemInfo,into (1,nElems)
 CALL WriteArrayToHDF5(File_ID,'ElemInfo',2,(/ElemInfoSize,nElems/),IntegerArray=ElemInfo)
 DEALLOCATE(ElemInfo)
 
-!WRITE SideInfo,into (1,nSides)   
+!WRITE SideInfo,into (1,nSides)
 CALL WriteArrayToHDF5(File_ID,'SideInfo',2,(/SideInfoSize,nSides/),IntegerArray=SideInfo)
 DEALLOCATE(SideInfo)
 
@@ -302,10 +302,10 @@ nBCs=nUserDefinedBoundaries
 ALLOCATE(BCNames(nBCs))
 ALLOCATE(BCType(4,nBCs))
 DO i=1,nBCs
-  BCNames(i)=BoundaryName(i) 
-  BCType(:,i)=BoundaryType(i,:) 
+  BCNames(i)=BoundaryName(i)
+  BCType(:,i)=BoundaryType(i,:)
 END DO
-! WRITE BC 
+! WRITE BC
 CALL WriteAttribute(File_ID,'nBCs',1,IntScalar=nBCs)
 
 CALL WriteArrayToHDF5(File_ID,'BCNames',1,(/nBCs/),StrArray=BCNames)
@@ -314,7 +314,7 @@ CALL WriteArrayToHDF5(File_ID,'BCType',2,(/4,nBcs/),IntegerArray=BCType)
 DEALLOCATE(BCNames)
 DEALLOCATE(BCType)
 
-!WRITE ElemWeight,into (1,nElems)  
+!WRITE ElemWeight,into (1,nElems)
 CALL WriteArrayToHDF5(File_ID,'ElemBarycenters',2,(/3,nElems/),RealArray=TRANSPOSE(ElemBarycenters))
 DEALLOCATE(ElemBarycenters)
 
@@ -383,14 +383,14 @@ INTEGER                        :: locnNodes,locnSides
 INTEGER                        :: iNode,iSide,iElem,i,iMortar
 TYPE(tSide),POINTER            :: aSide
 !===================================================================================================================================
-!fill ElementInfo. 
+!fill ElementInfo.
 ALLOCATE(ElemInfo(ElemInfoSize,1:nElems))
 ALLOCATE(ElemWeight(1:nElems))
 ElemInfo=0
 ElemWeight=1.  !equal weight for all elements
 Elemcounter=0
 Elemcounter(1,:)=(/104,204,105,115,205,106,116,206,108,118,208/)
-iNode  = 0 
+iNode  = 0
 iSide  = 0
 iElem  = 0
 Elem=>firstElem
@@ -402,7 +402,7 @@ DO WHILE(ASSOCIATED(Elem))
   DO WHILE(ASSOCIATED(aSide))
     locnSides = locnSides + aSide%nMortars
     aSide=>aSide%nextElemSide
-  END DO 
+  END DO
 
 
   IF(N.EQ.1)THEN
@@ -447,8 +447,8 @@ END DO
 
 
 !fill SideInfo
-ALLOCATE(SideInfo(SideInfoSize,1:nSides)) 
-SideInfo=0 
+ALLOCATE(SideInfo(SideInfoSize,1:nSides))
+SideInfo=0
 iSide=0
 Elem=>firstElem
 DO WHILE(ASSOCIATED(Elem))
@@ -462,7 +462,7 @@ DO WHILE(ASSOCIATED(Elem))
       ELSE
         IF(Side%nNodes.EQ.3)THEN
           SideInfo(SIDE_Type,iSide)=3
-        ELSE  
+        ELSE
           SideInfo(SIDE_Type,iSide)=10+Side%nNodes        ! Side Type: bilinear quad
         END IF
       END IF
@@ -471,30 +471,30 @@ DO WHILE(ASSOCIATED(Elem))
     END IF
     !Side ID
     SideInfo(SIDE_ID,iSide)=Side%ind
-    IF(.NOT.ISORIENTED(Side)) SideInfo(SIDE_ID,iSide)=-SideInfo(SIDE_ID,iSide)           
+    IF(.NOT.ISORIENTED(Side)) SideInfo(SIDE_ID,iSide)=-SideInfo(SIDE_ID,iSide)
     !BCID
     IF (ASSOCIATED(Side%BC)) THEN
       SideInfo(SIDE_BCID,    iSide)= Side%BC%BCIndex
       IF(Side%BC%BCIndex.EQ.0) WRITE(*,*)'DEBUG, Warning, BC ind =0'
-    ELSE 
+    ELSE
       SideInfo(SIDE_BCID,    iSide)= 0
     END IF
-      
+
     IF (Side%MortarType.GT.0) THEN ! Mortar master side (only implemented for Quad-sides!!!)
       IF(ASSOCIATED(Side%Connection)) CALL abort(__STAMP__,&
                                                  'Mortar master with connection is not allowed')
       IF(Side%flip.NE.0) STOP 'Problem with flip on mortar'
       SideInfo(SIDE_nbElemID,iSide)= -Side%MortarType
       SideInfo(SIDE_nbLocSide_flip,iSide)=0
-      DO iMortar=1,Side%nMortars 
+      DO iMortar=1,Side%nMortars
         iSide=iSide+1
-        SideInfo(SIDE_Type,    iSide)= MERGE(104,204,N.EQ.1) 
+        SideInfo(SIDE_Type,    iSide)= MERGE(104,204,N.EQ.1)
         SideInfo(SIDE_ID,      iSide)= Side%MortarSide(iMortar)%sp%ind       ! small are always master
         SideInfo(SIDE_nbElemID,iSide)= Side%MortarSide(iMortar)%sp%Elem%ind  ! neighbour Element ID
         SideInfo(SIDE_nbLocSide_flip,iSide)=0
         IF (ASSOCIATED(Side%MortarSide(iMortar)%sp%BC)) THEN
           SideInfo(SIDE_BCID,    iSide)= Side%MortarSide(iMortar)%sp%BC%BCIndex
-        ELSE 
+        ELSE
           SideInfo(SIDE_BCID,    iSide)= 0
         END IF
       END DO
@@ -544,8 +544,8 @@ ELSE ! CurvedNodes
     END DO
     Elem=>Elem%nextElem
   END DO
-END IF 
-  
+END IF
+
 IF(iNode.NE.nNodes) CALL abort(__STAMP__,&
                      'Sanity check: nNodes not equal to total number of nodes!')
 
@@ -576,15 +576,15 @@ INTEGER                        :: IDlist(1:nElems_in)  ! ?
 TYPE(tElemPtr)                 :: Elems(1:nElems_in)  ! ?
 REAL                           :: ElemBary(1:nElems_in,3)  ! ?
 INTEGER                        :: ElemID  ! ?
-INTEGER                        :: iNode 
+INTEGER                        :: iNode
 !===================================================================================================================================
 
 Elems(1)%ep=>firstElem
-DO ElemID=2,nElems_in 
+DO ElemID=2,nElems_in
   Elems(ElemID)%ep=>Elems(ElemID-1)%ep%nextElem
 END DO
 DO ElemID=1,nElems_in
-  IDList(ElemID)=ElemID 
+  IDList(ElemID)=ElemID
   ElemBary(ElemID,:)=0.
   DO iNode=1,Elems(ElemID)%ep%nNodes
     ElemBary(ElemID,:)=ElemBary(ElemID,:)+Elems(ElemID)%ep%Node(iNode)%np%x
@@ -592,7 +592,7 @@ DO ElemID=1,nElems_in
   ElemBary(ElemID,:)=ElemBary(ElemID,:)/REAL(Elems(ElemID)%ep%nNodes)
 END DO
 
-IF((MeshMode.EQ.11).AND. (.NOT.AdaptedMesh))THEN 
+IF((MeshMode.EQ.11).AND. (.NOT.AdaptedMesh))THEN
   ! for Meshmode=11: if no splitting was done, this is a structured single block, elem_IJK already defined
   CALL SortElemsBySpaceFillingCurve(nElems_in,REAL(Elem_IJK),IDList,1) !use IJK for space filling curve
 ELSE
@@ -601,24 +601,24 @@ END IF
 
 NULLIFY(Elems(IDlist(1))%ep%prevElem)
 firstElem=>Elems(IDlist(1))%ep
-DO ElemID=2,nElems_in 
+DO ElemID=2,nElems_in
   Elems(IDlist(ElemID-1))%ep%nextElem=>Elems(IDList(ElemID))%ep
   Elems(IDlist(ElemID))%ep%prevElem  =>Elems(IDList(ElemID-1))%ep
 END DO
-DO ElemID=1,nElems_in 
+DO ElemID=1,nElems_in
   Elems(IDlist(ElemID))%ep%ind=ElemID
 END DO
 IF(DebugVisu)THEN
   WRITE(*,*)'write space filling curve to sfc.dat'
   OPEN(UNIT=200,FILE='sfc.dat',STATUS='REPLACE')
-  DO ElemID=1,nElems_in 
+  DO ElemID=1,nElems_in
     WRITE(200,'(3E21.6)')ElemBary(IDlist(ElemID),:)
   END DO
   CLOSE(200)
 END IF
 IF(ALLOCATED(ElemBarycenters)) DEALLOCATE(ElemBarycenters)
 ALLOCATE(ElemBarycenters(1:nElems_in,3))
-DO ElemID=1,nElems_in 
+DO ElemID=1,nElems_in
   ElemBarycenters(ElemID,:)=ElemBary(IDlist(ElemID),:)
 END DO
 NULLIFY(Elems(IDlist(nElems_in))%ep%nextElem)
@@ -651,7 +651,7 @@ INTEGER(HID_T), INTENT(IN)     :: Loc_ID                                ! HDF5 f
 CHARACTER(LEN=*), INTENT(IN)   :: ArrayName                             ! Name of the array
 INTEGER,INTENT(IN)             :: Rank                                  ! number of dimensions
 INTEGER,INTENT(IN)             :: nVal(Rank)                            ! dimensions of the array
-REAL              ,DIMENSION(Rank),OPTIONAL,INTENT(IN) :: RealArray     ! Real array  
+REAL              ,DIMENSION(Rank),OPTIONAL,INTENT(IN) :: RealArray     ! Real array
 INTEGER           ,DIMENSION(Rank),OPTIONAL,INTENT(IN) :: IntegerArray  ! Integer array
 CHARACTER(LEN=255),DIMENSION(Rank),OPTIONAL,INTENT(IN) :: StrArray      ! String array
 !-----------------------------------------------------------------------------------------------------------------------------------
@@ -685,7 +685,7 @@ CALL H5SCLOSE_F(FileSpace, iError)
 
 ! Each process defines dataset in memory and writes it to the hyperslab in the file.
 Dimsf=nVal  ! Now we need the local array size
-offset=0  !ONLY SINGLE 
+offset=0  !ONLY SINGLE
 ! Create the data space in the memory
 IF(Dimsf(1) .NE. 0)THEN
   CALL H5SCREATE_SIMPLE_F(Rank, Dimsf, MemSpace, iError)


### PR DESCRIPTION
Instead of overwriting BC_Alpha=1 with the zCorrection, check if any of the periodic vectors is already aligned with z. If positive, use this vector. If not, add a new periodic vector.

Fixes #17.