### PR TITLE
Bugfix in CGNS readin.

### DIFF
--- a/src/readin/readin_CGNS.f90
+++ b/src/readin/readin_CGNS.f90
@@ -421,7 +421,7 @@ DO iSect=1,nSect ! Vol. and Face elems
   DEALLOCATE(LocalConnect)
   DEALLOCATE(ParentData)
 #if (PP_CGNS_VERSION>=4000)
-  DEALLOCATE(connect_offsets)
+  IF(SectionElemType .EQ. MIXED) DEALLOCATE(connect_offsets)
 #endif /*(PP_CGNS_VERSION>=4000)*/
 END DO !sections
 
@@ -1280,7 +1280,7 @@ DO iZone=1,nCGNSZones
     DEALLOCATE(LocalConnect)
     DEALLOCATE(ParentData)
 #if PP_CGNS_VERSION>=4000
-    DEALLOCATE(connect_offsets)
+    IF(SectionElemType .EQ. MIXED) DEALLOCATE(connect_offsets)
 #endif /*PP_CGNS_VERSION>=4000*/
   END DO !sections
 


### PR DESCRIPTION
 For `CGNS` version >4.0, the `connect_offsets` array is not allocated but tried to deallocate if the `SectionElemType` is not equal to `MIXED`. This is for instance a problem in the tutorials and unit tests introduced by #6 .