### PR TITLE
gitlabext.iag.uni-stuttgart.de discontinued

### DIFF
--- a/CMakeListsLib.txt
+++ b/CMakeListsLib.txt
@@ -34,7 +34,7 @@ IF("${GIT_ORIGIN}" MATCHES ".iag.uni-stuttgart.de")
   # Checked out using HTTPS
   # IF("${GIT_ORIGIN}" MATCHES "^https@")
   ELSE()
-    SET(LIBS_DLPATH "https://gitlabext.iag.uni-stuttgart.de/")
+    SET(LIBS_DLPATH "https://gitlab.iag.uni-stuttgart.de/")
   ENDIF()
 # Origin pointing to ILA
 ELSEIF("${GIT_ORIGIN}" MATCHES "ila.uni-stuttgart.de")


### PR DESCRIPTION
The gitlab moved to gitlab.iag.uni-stuttgart.de also for external access. Gitlabext has an invalid ssl cert and breaks automated git checkouts.