### PR TITLE
[cmake.hopr.instruction.settings] Adjusted cmake fro user-defined instruction settings

### DIFF
--- a/.github/workflows/cmake-ninja.yml
+++ b/.github/workflows/cmake-ninja.yml
@@ -54,7 +54,7 @@ jobs:
       shell: bash
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      run: cmake -G Ninja -B build -DCMAKE_BUILD_TYPE=Release -DLIBS_USE_MPI=OFF -DCMAKE_INSTALL_PREFIX=/usr
+      run: cmake -G Ninja -B build -DHOPR_INSTRUCTION=-mtune=generic -DCMAKE_BUILD_TYPE=Release -DLIBS_USE_MPI=OFF -DCMAKE_INSTALL_PREFIX=/usr
 
     - name: Build
       shell: bash

--- a/CMakeListsMachine.txt
+++ b/CMakeListsMachine.txt
@@ -60,81 +60,88 @@ INCLUDE(GNUInstallDirs)
 # =========================================================================
 # Set machine-specific definitions and settings
 # =========================================================================
-# HLRS HAWK / SuperMUC
-IF ("${CMAKE_HOSTNAME}" MATCHES "login")
-  MARK_AS_ADVANCED(FORCE C_PATH CXX_PATH Fortran_PATH)
+# Revert to default via -DHOPR_INSTRUCTION= once this value has been changed via, e.g., -DHOPR_INSTRUCTION=-mtune=generic
+IF(NOT DEFINED HOPR_INSTRUCTION)
+  SET(HOPR_INSTRUCTION "")
+ENDIF()
 
-  # HAWK and SuperMUC name their login nodes identically, so use OS distribution to identify
-  FIND_PROGRAM(LSB_RELEASE_EXEC lsb_release)
-  EXECUTE_PROCESS(COMMAND ${LSB_RELEASE_EXEC} -is OUTPUT_VARIABLE LSB_RELEASE_ID_SHORT OUTPUT_STRIP_TRAILING_WHITESPACE)
-  MARK_AS_ADVANCED(FORCE LSB_RELEASE_EXEC)
-  # HLRS HAWK
-  IF (LSB_RELEASE_ID_SHORT MATCHES "CentOS")
-    MESSAGE(STATUS "Compiling on Hawk")
+# HLRS HAWK / SuperMUC
+IF("${HOPR_INSTRUCTION}" STREQUAL "")
+  IF ("${CMAKE_HOSTNAME}" MATCHES "login")
+    MARK_AS_ADVANCED(FORCE C_PATH CXX_PATH Fortran_PATH)
+
+    # HAWK and SuperMUC name their login nodes identically, so use OS distribution to identify
+    FIND_PROGRAM(LSB_RELEASE_EXEC lsb_release)
+    EXECUTE_PROCESS(COMMAND ${LSB_RELEASE_EXEC} -is OUTPUT_VARIABLE LSB_RELEASE_ID_SHORT OUTPUT_STRIP_TRAILING_WHITESPACE)
+    MARK_AS_ADVANCED(FORCE LSB_RELEASE_EXEC)
+    # HLRS HAWK
+    IF (LSB_RELEASE_ID_SHORT MATCHES "CentOS")
+      MESSAGE(STATUS "Compiling on Hawk")
+      # Overwrite compiler target architecture
+      IF (CMAKE_Fortran_COMPILER_ID MATCHES "GNU" OR CMAKE_Fortran_COMPILER_ID MATCHES "Flang")
+        SET(HOPR_INSTRUCTION "-march=znver2")
+      ELSEIF (CMAKE_Fortran_COMPILER_ID MATCHES "Intel")
+        SET(HOPR_INSTRUCTION "-xCORE-AVX2")
+      ENDIF()
+      # Use AMD Optimized Lapack/BLAS
+      # SET(BLA_VENDOR "FLAME")
+    # SuperMUC
+    ELSEIF (LSB_RELEASE_ID_SHORT MATCHES "SUSE")
+      MESSAGE(STATUS "Compiling on SuperMUC")
+      # Overwrite compiler target architecture
+      IF (CMAKE_Fortran_COMPILER_ID MATCHES "GNU" OR CMAKE_Fortran_COMPILER_ID MATCHES "Flang")
+        SET(HOPR_INSTRUCTION "-march=skylake-avx512")
+      ELSEIF (CMAKE_Fortran_COMPILER_ID MATCHES "Intel")
+        SET(HOPR_INSTRUCTION "-xSKYLAKE-AVX512")
+        # Explicitely enable usage of AVX512 registers
+        SET (CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -qopt-zmm-usage=high")
+      ENDIF()
+    ENDIF()
+
+  # IAG Prandtl
+  ELSEIF("${CMAKE_HOSTNAME}" MATCHES "^prandtl")
+    MESSAGE(STATUS "Compiling on Prandtl")
+    MARK_AS_ADVANCED(FORCE C_PATH CXX_PATH Fortran_PATH)
+    SET(HOPR_INSTRUCTION "-march=native")
+
+  # IAG Grafik01/Grafik02
+  ELSEIF ("${CMAKE_HOSTNAME}" MATCHES "^grafik0")
+    MESSAGE(STATUS "Compiling on ${CMAKE_HOSTNAME}")
+    MARK_AS_ADVANCED(FORCE C_PATH CXX_PATH Fortran_PATH)
+    SET(HOPR_INSTRUCTION "-march=native")
+
+  ELSEIF ("${CMAKE_HOSTNAME}" MATCHES "^ilahead1")
+    MESSAGE(STATUS "Compiling on ILA cluster")
+    MARK_AS_ADVANCED(FORCE C_PATH CXX_PATH Fortran_PATH)
     # Overwrite compiler target architecture
     IF (CMAKE_Fortran_COMPILER_ID MATCHES "GNU" OR CMAKE_Fortran_COMPILER_ID MATCHES "Flang")
-      SET(HOPR_INSTRUCTION "-march=znver2")
+      SET(HOPR_INSTRUCTION "-march=core-avx2")
     ELSEIF (CMAKE_Fortran_COMPILER_ID MATCHES "Intel")
       SET(HOPR_INSTRUCTION "-xCORE-AVX2")
     ENDIF()
-    # Use AMD Optimized Lapack/BLAS
-    # SET(BLA_VENDOR "FLAME")
-  # SuperMUC
-  ELSEIF (LSB_RELEASE_ID_SHORT MATCHES "SUSE")
-    MESSAGE(STATUS "Compiling on SuperMUC")
-    # Overwrite compiler target architecture
-    IF (CMAKE_Fortran_COMPILER_ID MATCHES "GNU" OR CMAKE_Fortran_COMPILER_ID MATCHES "Flang")
-      SET(HOPR_INSTRUCTION "-march=skylake-avx512")
-    ELSEIF (CMAKE_Fortran_COMPILER_ID MATCHES "Intel")
-      SET(HOPR_INSTRUCTION "-xSKYLAKE-AVX512")
-      # Explicitely enable usage of AVX512 registers
-      SET (CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -qopt-zmm-usage=high")
-    ENDIF()
-  ENDIF()
 
-# IAG Prandtl
-ELSEIF("${CMAKE_HOSTNAME}" MATCHES "^prandtl")
-  MESSAGE(STATUS "Compiling on Prandtl")
-  MARK_AS_ADVANCED(FORCE C_PATH CXX_PATH Fortran_PATH)
-  SET(HOPR_INSTRUCTION "-march=native")
-
-# IAG Grafik01/Grafik02
-ELSEIF ("${CMAKE_HOSTNAME}" MATCHES "^grafik0")
-  MESSAGE(STATUS "Compiling on ${CMAKE_HOSTNAME}")
-  MARK_AS_ADVANCED(FORCE C_PATH CXX_PATH Fortran_PATH)
-  SET(HOPR_INSTRUCTION "-march=native")
-
-ELSEIF ("${CMAKE_HOSTNAME}" MATCHES "^ilahead1")
-  MESSAGE(STATUS "Compiling on ILA cluster")
-  MARK_AS_ADVANCED(FORCE C_PATH CXX_PATH Fortran_PATH)
-  # Overwrite compiler target architecture
-  IF (CMAKE_Fortran_COMPILER_ID MATCHES "GNU" OR CMAKE_Fortran_COMPILER_ID MATCHES "Flang")
-    SET(HOPR_INSTRUCTION "-march=core-avx2")
-  ELSEIF (CMAKE_Fortran_COMPILER_ID MATCHES "Intel")
-    SET(HOPR_INSTRUCTION "-xCORE-AVX2")
-  ENDIF()
-
-ELSEIF ("${CMAKE_HOSTNAME}" MATCHES "^xenon")
-  MESSAGE(STATUS "Compiling on ILA student cluster")
-  MARK_AS_ADVANCED(FORCE C_PATH CXX_PATH Fortran_PATH)
-  SET(HOPR_INSTRUCTION "-march=native")
-
-ELSEIF ("${CMAKE_FQDN_HOST}" MATCHES "gitlab.ila.uni-stuttgart.de")
-  MESSAGE(STATUS "Compiling on ILA Gitlab")
-  ADD_DEFINITIONS(-DVDM_ANALYTICAL)
-  SET(HOPR_INSTRUCTION "-march=native")
-
-ELSE()
-  MESSAGE(STATUS "Compiling on a generic machine")
-  # Set compiler target architecture
-  IF (CMAKE_Fortran_COMPILER_ID MATCHES "GNU" OR CMAKE_Fortran_COMPILER_ID MATCHES "Flang" )
+  ELSEIF ("${CMAKE_HOSTNAME}" MATCHES "^xenon")
+    MESSAGE(STATUS "Compiling on ILA student cluster")
+    MARK_AS_ADVANCED(FORCE C_PATH CXX_PATH Fortran_PATH)
     SET(HOPR_INSTRUCTION "-march=native")
-  ELSEIF (CMAKE_Fortran_COMPILER_ID MATCHES "Intel")
-    SET(HOPR_INSTRUCTION "-xHost")
+
+  ELSEIF ("${CMAKE_FQDN_HOST}" MATCHES "gitlab.ila.uni-stuttgart.de")
+    MESSAGE(STATUS "Compiling on ILA Gitlab")
+    ADD_DEFINITIONS(-DVDM_ANALYTICAL)
+    SET(HOPR_INSTRUCTION "-march=native")
+
+  ELSE()
+    MESSAGE(STATUS "Compiling on a generic machine")
+    # Set compiler target architecture
+    IF (CMAKE_Fortran_COMPILER_ID MATCHES "GNU" OR CMAKE_Fortran_COMPILER_ID MATCHES "Flang" )
+      SET(HOPR_INSTRUCTION "-march=native")
+    ELSEIF (CMAKE_Fortran_COMPILER_ID MATCHES "Intel")
+      SET(HOPR_INSTRUCTION "-xHost")
+    ENDIF()
   ENDIF()
 ENDIF()
 
-MESSAGE(STATUS "Compiling with [${CMAKE_Fortran_COMPILER_ID}] (v${CMAKE_Fortran_COMPILER_VERSION}) fortran compiler using [${HOPR_INSTRUCTION}] instruction")
+MESSAGE(STATUS "Compiling Release/Profile with [${CMAKE_Fortran_COMPILER_ID}] (v${CMAKE_Fortran_COMPILER_VERSION}) fortran compiler using HOPR_INSTRUCTION [${HOPR_INSTRUCTION}] instruction")
 
 # =========================================================================
 # COMPILER FLAGS

--- a/CMakeListsMachine.txt
+++ b/CMakeListsMachine.txt
@@ -70,12 +70,11 @@ IF("${HOPR_INSTRUCTION}" STREQUAL "")
   IF ("${CMAKE_HOSTNAME}" MATCHES "login")
     MARK_AS_ADVANCED(FORCE C_PATH CXX_PATH Fortran_PATH)
 
-    # HAWK and SuperMUC name their login nodes identically, so use OS distribution to identify
-    FIND_PROGRAM(LSB_RELEASE_EXEC lsb_release)
-    EXECUTE_PROCESS(COMMAND ${LSB_RELEASE_EXEC} -is OUTPUT_VARIABLE LSB_RELEASE_ID_SHORT OUTPUT_STRIP_TRAILING_WHITESPACE)
-    MARK_AS_ADVANCED(FORCE LSB_RELEASE_EXEC)
+    # HAWK and SuperMUC name their login nodes identically, so use the Fully Qualified Domain Name (FQDN) to identify
+    CMAKE_HOST_SYSTEM_INFORMATION(RESULT FQDN QUERY FQDN)
+    MARK_AS_ADVANCED(FORCE FQDN)
     # HLRS HAWK
-    IF (LSB_RELEASE_ID_SHORT MATCHES "CentOS")
+    IF (FQDN MATCHES "hawk.hww.hlrs.de")
       MESSAGE(STATUS "Compiling on Hawk")
       # Overwrite compiler target architecture
       IF (CMAKE_Fortran_COMPILER_ID MATCHES "GNU" OR CMAKE_Fortran_COMPILER_ID MATCHES "Flang")
@@ -86,7 +85,7 @@ IF("${HOPR_INSTRUCTION}" STREQUAL "")
       # Use AMD Optimized Lapack/BLAS
       # SET(BLA_VENDOR "FLAME")
     # SuperMUC
-    ELSEIF (LSB_RELEASE_ID_SHORT MATCHES "SUSE")
+    ELSEIF (FQDN MATCHES "sng.lrz.de")
       MESSAGE(STATUS "Compiling on SuperMUC")
       # Overwrite compiler target architecture
       IF (CMAKE_Fortran_COMPILER_ID MATCHES "GNU" OR CMAKE_Fortran_COMPILER_ID MATCHES "Flang")
@@ -124,12 +123,6 @@ IF("${HOPR_INSTRUCTION}" STREQUAL "")
     MESSAGE(STATUS "Compiling on ILA student cluster")
     MARK_AS_ADVANCED(FORCE C_PATH CXX_PATH Fortran_PATH)
     SET(HOPR_INSTRUCTION "-march=native")
-
-  ELSEIF ("${CMAKE_FQDN_HOST}" MATCHES "gitlab.ila.uni-stuttgart.de")
-    MESSAGE(STATUS "Compiling on ILA Gitlab")
-    ADD_DEFINITIONS(-DVDM_ANALYTICAL)
-    SET(HOPR_INSTRUCTION "-march=native")
-
   ELSE()
     MESSAGE(STATUS "Compiling on a generic machine")
     # Set compiler target architecture
@@ -141,7 +134,7 @@ IF("${HOPR_INSTRUCTION}" STREQUAL "")
   ENDIF()
 ENDIF()
 
-MESSAGE(STATUS "Compiling Release/Profile with [${CMAKE_Fortran_COMPILER_ID}] (v${CMAKE_Fortran_COMPILER_VERSION}) fortran compiler using HOPR_INSTRUCTION [${HOPR_INSTRUCTION}] instruction")
+MESSAGE(STATUS "Compiling Release/Profile with [${CMAKE_Fortran_COMPILER_ID}] (v${CMAKE_Fortran_COMPILER_VERSION}) fortran compiler using HOPR_INSTRUCTION [${HOPR_INSTRUCTION}] instructions.")
 
 # =========================================================================
 # COMPILER FLAGS
@@ -160,7 +153,7 @@ IF (CMAKE_Fortran_COMPILER_ID MATCHES "GNU")
   SET (CMAKE_Fortran_FLAGS_RELEASE   "${CMAKE_Fortran_FLAGS}     -O3 ${HOPR_INSTRUCTION} -finline-functions -fstack-arrays")
   SET (CMAKE_Fortran_FLAGS_PROFILE   "${CMAKE_Fortran_FLAGS} -pg -O3 ${HOPR_INSTRUCTION} -finline-functions -fstack-arrays")
   SET (CMAKE_Fortran_FLAGS_DEBUG     "${CMAKE_Fortran_FLAGS} -g  -Og -ggdb3 -ffpe-trap=invalid -fbounds-check -finit-real=snan -fbacktrace  -Wall")
-  SET (CMAKE_Fortran_FLAGS_SANITIZE  "${CMAKE_Fortran_FLAGS} -g  -Og -ggdb3 -ffpe-trap=invalid,zero,overflow -fbounds-check -finit-real=snan -fbacktrace  -Wall -fsanitize=address,undefined,leak -fno-omit-frame-pointer -Wc-binding-type -Wuninitialized -pedantic")
+  SET (CMAKE_Fortran_FLAGS_SANITIZE  "${CMAKE_Fortran_FLAGS} -g  -Og -ggdb3 -ffpe-trap=invalid,zero,overflow,denorm -fbounds-check -finit-real=snan -fbacktrace  -Wall -fsanitize=address,undefined,leak -fno-omit-frame-pointer -Wc-binding-type -Wuninitialized -pedantic")
   # add flags only for compiling not linking!
   # Compile flags depend on the generator
   IF(NOT "${CMAKE_GENERATOR}" MATCHES "Ninja")
@@ -240,7 +233,9 @@ MARK_AS_ADVANCED(FORCE CMAKE_Fortran_FLAGS)
 MARK_AS_ADVANCED(FORCE CMAKE_Fortran_FLAGS_RELEASE)
 MARK_AS_ADVANCED(FORCE CMAKE_Fortran_FLAGS_PROFILE)
 MARK_AS_ADVANCED(FORCE CMAKE_Fortran_FLAGS_DEBUG)
+MARK_AS_ADVANCED(FORCE CMAKE_Fortran_FLAGS_SANITIZE)
 SET(CMAKE_Fortran_FLAGS            "${CMAKE_Fortran_FLAGS}"          CACHE STRING "Default compiler flags" FORCE)
 SET(CMAKE_Fortran_FLAGS_RELEASE    "${CMAKE_Fortran_FLAGS_RELEASE}"  CACHE STRING "Release compiler flags" FORCE)
 SET(CMAKE_Fortran_FLAGS_PROFILE    "${CMAKE_Fortran_FLAGS_PROFILE}"  CACHE STRING "Profile compiler flags" FORCE)
 SET(CMAKE_Fortran_FLAGS_DEBUG      "${CMAKE_Fortran_FLAGS_DEBUG}"    CACHE STRING "Debug compiler flags"   FORCE)
+SET(CMAKE_Fortran_FLAGS_SANITIZE   "${CMAKE_Fortran_FLAGS_SANITIZE}" CACHE STRING "Sanitize compiler flags"  FORCE)

--- a/docs/documentation/userguide/installation.md
+++ b/docs/documentation/userguide/installation.md
@@ -129,7 +129,26 @@ For compiling HOPR, create a new sub-directory, e.g. "build" . Inside that direc
 Here you can specify library paths and options. If no preinstallied libraries for HDF5 and CGNS are found these libraries will be
 downloaded and built automatically. Press `c` to configure and `g` to create the Makefiles. Finally compile HOPR by typing `make`.
 
-If the user does not need the cgns library (i.e. HOPR mesh is not built via a cgns input meshfile), the cmake option `LIBS_USE_CGNS` can be set to `OFF`, which skips the installation of the cgns library. Note that the cmake tests that depend on CGNS will not be executed. 
+``LIBS_USE_CGNS``: If the user does not need the cgns library (i.e. HOPR mesh is not built via a cgns input meshfile), the cmake
+option `LIBS_USE_CGNS` can be set to `OFF`, which skips the installation of the cgns library.
+Note that the cmake tests that depend on CGNS will not be executed.
+
+``HOPR_INSTRUCTION``: Processor instruction settings (mainly depending on the hardware on which the compilation process is
+  performed or the target hardware where HOPR will be executed). This variable is set automatically depending on the machine where
+  HOPR is compiled. CMake prints the value of this parameter during configuration
+
+      -- Compiling Release/Profile with [GNU] (v12.2.0) fortran compiler using HOPR_INSTRUCTION [-march=native] instruction
+
+  When compiling HOPR on one machine and executing the code on a different one, the instruction setting should be set to
+  `generic`. This can be accomplished by running
+
+      cmake -DHOPR_INSTRUCTION=-mtune=generic
+
+  To reset the instruction settings, run cmake again but with
+
+      -DHOPR_INSTRUCTION=
+
+  which resorts to using the automatic determination depending on the detected machine.
 
 (sec:hdf5-installation)=
 ### Installing/setting up HDF5


### PR DESCRIPTION
Adjusted cmake fro user-defined instruction settings (HOPR_INSTRUCTION) to compile hopr for general cpu architectures. This is also used for the AppImage of hopr.