### PR TITLE
[hotfix.readin.stringlength] Hotfix read-in long strings from parameter-file

### DIFF
--- a/src/readin/readintools.f90
+++ b/src/readin/readintools.f90
@@ -505,7 +505,7 @@ CHARACTER(LEN=*),INTENT(IN),OPTIONAL   :: IniFile                    ! Name of i
 !-----------------------------------------------------------------------------------------------------------------------------------
 ! LOCAL VARIABLES
 TYPE(tString),POINTER                  :: Str1=>NULL(),Str2=>NULL()  ! ?
-CHARACTER(LEN=255)                     :: HelpStr,Str  ! ?
+CHARACTER(LEN=:),ALLOCATABLE           :: HelpStr
 CHARACTER(LEN=300)                     :: File  ! ?
 TYPE(Varying_String)                   :: aStr,bStr,Separator  ! ?
 INTEGER                                :: EOF  ! ?
@@ -533,8 +533,6 @@ DO WHILE(EOF.NE.IOSTAT_END)
   IF(.NOT.ASSOCIATED(Str1)) CALL GetNewString(Str1)
     ! Read line from file
     CALL Get(103,aStr,iostat=EOF)
-    Str=aStr
-!IPWRITE(*,*)'Reading: ',Str,EOF
     IF (EOF.NE.IOSTAT_END) THEN
       ! Remove comments with "!"
       CALL Split(aStr,Str1%Str,"!")
@@ -555,7 +553,8 @@ DO WHILE(EOF.NE.IOSTAT_END)
       ! Replace commas
       Str1%Str=Replace(Str1%Str,","," ",Every=.true.)
       ! Lower case
-      CALL LowCase(CHAR(Str1%Str),HelpStr)
+      HelpStr = CHAR(Str1%Str)              ! define HelpStr to set size of deferred-shape array
+      CALL LowCase(CHAR(Str1%Str),HelpStr)  ! overwrite HelpStr without modifying size
       ! If we have a remainder (no comment only)
       IF(LEN_TRIM(HelpStr).GT.2) THEN
         Str1%Str=Var_Str(HelpStr)


### PR DESCRIPTION
when reading parameter-file, cast varying_string to deferred-shape CHAR array (instead of fixed-length CHAR array) to avoid truncation of long input lines

use case: periodic box where corner coordinates are irrational numbers, e.g. as obtained from trigonometric relations -> coordinates have to be given with sufficient decimals for opposite sides to be identified as conforming