### PR TITLE
Fixed AppImage creation + update version to v1.2.1

### DIFF
--- a/.github/workflows/cmake-ninja.yml
+++ b/.github/workflows/cmake-ninja.yml
@@ -75,6 +75,8 @@ jobs:
         cp ../docs/Meshformat/pics/HOPR_logo.png AppDir/usr/share/icons/hopr.png
         curl -L -O https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage
         chmod +x linuxdeploy-x86_64.AppImage
+        mkdir -p AppDir/usr/share/icons/hicolor/64x64/apps/
+        ln -sf ../../../hopr.png AppDir/usr/share/icons/hicolor/64x64/apps/
         tree AppDir
         ./linuxdeploy-x86_64.AppImage --appdir AppDir --output appimage --desktop-file=../hopr.desktop
 
@@ -116,7 +118,7 @@ jobs:
     - name: Upload artifacts
       uses: actions/upload-artifact@v3
       with:
-        name: hopr-binary-v1.2.0
+        name: hopr-binary-v1.2.1
         path: artifacts
 
     - name: Upload release asset

--- a/docs/documentation/developerguide/appimage.md
+++ b/docs/documentation/developerguide/appimage.md
@@ -35,7 +35,29 @@ Next, download the AppImage executable and run
 
     ./linuxdeploy-x86_64.AppImage --appdir AppDir --output appimage --desktop-file=../hopr.desktop
 
+If an error is encountered, see the Section {ref}`developerguide/appimage:Troubleshooting` section for a possible solution.
 The executable should be created in the top-level directory, e.g.,
 
     hopr-2de94ad-x86_64.AppImage
+
+# Troubleshooting
+
+This section collects typical errors that are encountered when trying to build the AppImage.
+
+## dlopen(): error loading libfuse.so.2
+
+If the error
+
+    dlopen(): error loading libfuse.so.2
+
+    AppImages require FUSE to run.
+    You might still be able to extract the contents of this AppImage
+    if you run it with the --appimage-extract option.
+    See https://github.com/AppImage/AppImageKit/wiki/FUSE
+    for more information
+
+is encountered, this might be due to a missing fuse installation.
+On Debian/Ubuntu systems, simply run
+
+    sudo apt install libfuse2
 

--- a/docs/documentation/requirements.txt
+++ b/docs/documentation/requirements.txt
@@ -3,6 +3,7 @@
 # Defining the exact version will make sure things don't break
 sphinx==7.0.0
 sphinx_rtd_theme==2.0.0
+sphinx_rtd_size==0.2.0
 readthedocs-sphinx-search==0.3.2
 myst_parser==2.0.0
 sphinxcontrib.bibtex==2.5.0

--- a/src/globals.f90
+++ b/src/globals.f90
@@ -56,7 +56,7 @@ LOGICAL                     :: Logging                    ! Set .TRUE. to activa
 
 INTEGER,PARAMETER           :: MajorVersion = 1           !> HoprVersion saved in each hdf5 file with hdf5 header
 INTEGER,PARAMETER           :: MinorVersion = 2           !> HoprVersion saved in each hdf5 file with hdf5 header
-INTEGER,PARAMETER           :: PatchVersion = 0           !> HoprVersion saved in each hdf5 file with hdf5 header
+INTEGER,PARAMETER           :: PatchVersion = 1           !> HoprVersion saved in each hdf5 file with hdf5 header
 INTEGER,PARAMETER           :: HoprVersionInt = PatchVersion+MinorVersion*100+MajorVersion*10000 !> Hopr version number saved in each hdf5 file with hdf5 header
 CHARACTER(LEN=10)           :: HoprVersionStr             !> Hopr version string saved in each hdf5 file with hdf5 header
 


### PR DESCRIPTION
- AppImage creation: The entry `Icon=hopr` in `hopr.desktop` now requires an icon file under `AppDir/usr/share/icons/hicolor/64x64/apps`, which is created via

      mkdir -p AppDir/usr/share/icons/hicolor/64x64/apps/
      ln -sf ../../../hopr.png AppDir/usr/share/icons/hicolor/64x64/apps

  in the `.github/workflows/cmake-ninja.yml` GitHub Actions config file.
- Increased version number to v.1.2.1 for patch version release that contains the fix for ReadTheDoc