### PR TITLE
Apply Global Shift to Mesh Coordinates

### DIFF
--- a/src/mesh/mesh_vars.f90
+++ b/src/mesh/mesh_vars.f90
@@ -220,9 +220,11 @@ LOGICAL                        :: generateFEMconnectivity! Flag for generating a
 TYPE(tElem) ,POINTER           :: firstElem              ! pointer to first element in order to start a loop
 TYPE(tElem) ,POINTER           :: firstSplitElem         ! pointer to first element in splitted elem list for curveds
 LOGICAL                        :: doScale                ! scaling factor gt realtolerance
-LOGICAL                        :: preScale               ! apply scaling after readin or before output
 LOGICAL                        :: postScale              ! apply scaling after readin or before output
 REAL                           :: MeshScale              ! scaling factor applied to Node Coordinates during read in
+LOGICAL                        :: doShift                ! scaling factor gt realtolerance
+LOGICAL                        :: postShift              ! apply scaling after readin or before output
+REAL                           :: MeshShift(3)           ! shifting vector applied to Node Coordinates during read in
 REAL                           :: SpaceQuandt            ! Characteristic length in the mesh. Used as tolerance
 REAL                           :: minDX                  ! smallest edge length
 REAL                           :: maxDX(3)               ! Used for search mesh

--- a/tutorials/1-06-curved-postdeform/parameter_cylinderinchannel.ini
+++ b/tutorials/1-06-curved-postdeform/parameter_cylinderinchannel.ini
@@ -1,0 +1,141 @@
+DEFVAR=(INT):    ia = 004    ! no. elems in angular direction top/bottom
+DEFVAR=(INT):    ial= 002    ! no. elems in angular direction left (inflow)
+DEFVAR=(INT):    iar= 005    ! no. elems in angular direction right (wake)
+DEFVAR=(INT):    ir = 006    ! no. elems in radial  direction
+DEFVAR=(INT):    iz = 001    ! no. elems in z
+DEFVAR=(INT):    iw = 012    ! no. elems in wake
+DEFVAR=(REAL):   fr = 1.2    ! radial stretching factor in ring
+DEFVAR=(REAL):   fw = 1.1    ! streamwise stretching factor in wake
+DEFVAR=(REAL):   rm = 1.0    ! middle square dim
+DEFVAR=(REAL):   r0 = 5.93969696196699920 ! = sqrt(2.)*ymax/(PostDeform_R0)
+DEFVAR=(REAL):   r1 = 5.65685424949238019 ! = sqrt(2.)*ymin/(PostDeform_R0)
+DEFVAR=(REAL):   lx = 56.5685424949238020 ! = sqrt(2.)*(xtotal-2.)/(PostDeform_R0)
+DEFVAR=(REAL):   lz = 1.     ! length of domain in z
+!================================================================================================================================= !
+! 2D cylinder in channel following (all measures factor 10 larger) 2D-2 case by:
+!       - "Benchmark Computations of Laminar Flow Around a Cylinder", Schäfer, Turek, 1996.
+!         (http://www.featflow.de/en/benchmarks/cfdbenchmarking/flow/dfg_benchmark2_re100.html)
+!
+!            ymin       ymin                 xmax - 2*ymin
+!        |<-------->|<--------->|<------------------------------------->|
+!     -- .--------------------------------------------------------------.
+!      ^ |          ^           |                                       |
+! ymax | |          |      ---- |                                       |
+!      | |        **|**       ^ |                                       |
+!      v |      **  |  **   R0| |                                       |
+!     -- |     **   0------>  | |                   wake                |
+!      ^ |      **     **     v |                                       |
+! ymin | |        *****    ---- |                                       |
+!      v |                      |                                       |
+!     -- '--------------------------------------------------------------'
+!        |<------------------------------------------------------------>|
+!                                   xtotal
+!
+! Explanation:
+! ----------------
+!
+! The cylinder is defined in [-1,1]^1 with diameter=1, and is created using a radius of PostDeform_R0=0.5. The r0 and r1 values,
+! i.e. the maximum/minimum y-values of the mesh (r0 and r1), are calculated as follows to account for the PostDeform:
+!   r0 = sqrt(2.)*ymax/(PostDeform_R0)   ,with ymax = 2.1
+!   r1 = sqrt(2.)*ymin/(PostDeform_R0)   ,with ymin = 2.0
+!
+! Similarly, the maximum x coordinate of the domain "lx" (i.e. from 0 to end of domain) can be computed as:
+!   lx = sqrt(2.)*(xtotal-ymin)/(PostDeform_R0)  ,with xtotal = 22
+!
+! Note that the cylinder is thus embedded in a rectangle that is longer in positive y-axis side as detailed in the reference.
+! The mesh consits of 5 zones. 4 to build the first part around the cylinder:
+!       - left:  [-r1,-r1] to [-rm,-rm]
+!       - right: [ rm,-rm] to [ r1, r0]
+!       - upper: [-rm, rm] to [ r1, r0]
+!       - lower: [-r1,-r1] to [ rm,-rm]
+!
+! And lastly the "wake" part that is a single structured block that extends the mesh in streamwise direction to x-coordinate "lx".
+!       - wake:  [r1,-r1,0] to [lx,r0,0]
+!
+! The final step is to shift the final mesh by vector:
+!    MeshShift = (/ ymin, -(ymax-ymin)/2, 0 /)
+! such that the domain is symmetric around the y-axis and the domain is within [0,22.] x [-2.05,2.05] x [0,1.]
+! In order to obtain domain from paper with y\in[0,H], use instead:
+!    MeshShift = (/ ymin, ymin, 0/)
+!
+!================================================================================================================================= !
+! OUTPUT
+!================================================================================================================================= !
+ProjectName  = CylinderInChannel          ! Name of output files
+Debugvisu    = T                          ! Visualize mesh and boundary conditions (tecplot ascii)
+checkElemJacobians=T
+NVisu=12
+
+!================================================================================================================================= !
+! MESH
+!================================================================================================================================= !
+Mode         =1                           ! Mode for Cartesian boxes
+nZones       =5                           ! number of boxes
+! left
+Corner       =(/-r1,-r1,0. ,,-rm,-rm,0. ,,-rm,rm,0. ,,  -r1,r0,0.,, -r1,-r1,lz ,,-rm,-rm,lz ,,-rm,rm,lz ,,  -r1,r0,lz /)
+nElems       =(/ir,ial,iz/)             ! number of elements in each direction
+BCIndex      =(/1,0,7,0,5,6/)           ! Indices of Boundary Conditions
+factor       =(/-fr,1.,1./)             ! stretching
+elemtype     =108                       ! element type (108: Hexahedral)
+! right
+Corner       =(/rm,-rm,0. ,,r1,-r1,0. ,,r1,r0,0. ,,  rm,rm,0.,, rm,-rm,lz ,,r1,-r1,lz ,,r1,r0,lz ,,  rm,rm,lz /)
+nElems       =(/ir,iar,iz/)             ! number of elements in each direction
+!BCIndex      =(/1,0,3,0,7,6/)          ! Indices of Boundary Conditions
+BCIndex      =(/1,0,0,0,7,6/)           ! Indices of Boundary Conditions
+elemtype     =108                       ! element type (108: Hexahedral)
+factor       =(/fr,1.,1./)              ! stretching
+! upper
+Corner       =(/-rm,rm,0. ,,rm,rm,0. ,,r1,r0,0. ,,  -r1,r0,0.,, -rm,rm,lz ,,rm,rm,lz ,,r1,r0,lz ,,  -r1,r0,lz /)
+nElems       =(/ia,ir,iz/)              ! number of elements in each direction
+BCIndex      =(/1,7,0,4,0,6/)           ! Indices of Boundary Conditions
+elemtype     =108                       ! element type (108: Hexahedral)
+factor       =(/1.,fr,1./)              ! stretching
+! lower
+Corner       =(/-r1,-r1,0. ,,r1,-r1,0. ,,rm,-rm,0. ,,  -rm,-rm,0.,, -r1,-r1,lz ,,r1,-r1,lz ,,rm,-rm,lz ,,  -rm,-rm,lz /)
+nElems       =(/ia,ir,iz/)              ! number of elements in each direction
+BCIndex      =(/1,2,0,7,0,6/)           ! Indices of Boundary Conditions
+elemtype     =108                       ! element type (108: Hexahedral)
+factor       =(/1.,-fr,1./)             ! stretching
+! wake
+Corner       =(/r1,-r1,0. ,,lx,-r1,0. ,,lx,r0,0. ,,  r1,r0,0.,, r1,-r1,lz ,,lx,-r1,lz ,,lx,r0,lz ,,  r1,r0,lz /)
+nElems       =(/iw,iar,iz/)             ! number of elements in each direction
+BCIndex      =(/1,2,3,4,0,6/)           ! Indices of Boundary Conditions
+factor       =(/fw,1.,1./)              ! stretching
+elemtype     =108                       ! element type (108: Hexahedral)
+
+useCurveds   =T
+BoundaryOrder=6
+
+!================================================================================================================================= !
+! BOUNDARY CONDITIONS
+!================================================================================================================================= !
+BoundaryName=BC_zminus                  ! BC index 1 (from  position in parameterfile)
+BoundaryType=(/1,0,0,1/)                ! (/ Type, curveIndex, State, alpha /)
+BoundaryName=BC_wall_lower              ! BC index 2
+BoundaryType=(/3,0,0,0/)
+BoundaryName=BC_xplus                   ! BC index 3
+BoundaryType=(/24,0,1,0/)
+BoundaryName=BC_wall_upper              ! BC index 4
+BoundaryType=(/3,0,0,0/)
+BoundaryName=BC_xminus                  ! BC index 5
+BoundaryType=(/2,0,0,0/)
+BoundaryName=BC_zplus                   ! BC index 6
+BoundaryType=(/1,0,0,-1/)
+BoundaryName=BC_wall_cylinder           ! BC index 7
+BoundaryType=(/3,0,0,0/)
+vv=(/0.,0.,lz/)
+
+MeshPostDeform=3      ! deforms [-1,1]^2 to a cylinder with radius Postdeform_R0 and goes back to box [-4,4]^2
+PostDeform_R0=0.5
+
+MeshShift = (/2.,-0.05,0./) ! Shift final mesh such that it is within [0,22.] x [-2.05,2.05] x [0,1.]
+
+!================================================================================================================================= !
+! Z Correction
+!================================================================================================================================= !
+OrientZ       = T
+dozcorrection = T
+zPeriodic     = T
+zLength       = lz
+zstart        = 0.
+nElemsZ       = iz


### PR DESCRIPTION
Implements a new feature that allows to shift the mesh coordinates using a global shifting vector `MeshShift(3)`.

This feature is particularly useful in cases where the PostDeform functionality is used, which typically acts on a predescribed area of the mesh (i.e. the spherical deformation assuming the origin to be the center of the sphere). In the actual simulation or if other transformation steps are performed it might be beneficial to move that origin to another location after readin from external mesh generators or before writeout, since the simulation (initial/boundary conditions) might expect another location of the coordinate system's origin. The default behavior doesn't change, so it's completely backwards compatible.

One example where this functionality can be useful is a mesh similar to the `2D-2` case defined in: [Benchmark Computations of Laminar Flow Around a Cylinder, Schäfer et al. 1996.](https://doi.org/10.1007/978-3-322-89849-4_39).
The parameter file to generate such a mesh (including shifting) is also added as `tutorials/1-06-curved-postdeform/parameter_cylinderinchannel.ini`, which also serves as a unit test for the functionality.

The actual shifting is performed in the routines already available for the `MeshScale` functionality. Scaling and shifting can be both applied independently either just after readin and before writing the mesh to disk. If both are applied in the same stage, scaling is always applied first before shifting the coordinates.

I hope that there is no identical functionality implemented yet that I overlooked...