### PR TITLE
[fix.innerBC.cubitMesh] Bugfix in AbortProg and fixes for inner BCs

### DIFF
--- a/src/globals.f90
+++ b/src/globals.f90
@@ -132,8 +132,19 @@ REAL,OPTIONAL,INTENT(IN)                     :: RealInfoOpt     ! Error info (re
 INTEGER                           :: IntInfo         ! Error info (integer)
 REAL                              :: RealInfo        ! Error info (real)
 !===================================================================================================================================
-IntInfo  = MERGE(IntInfoOpt ,999 ,PRESENT(IntInfoOpt) )
-RealInfo = MERGE(RealInfoOpt,999.,PRESENT(RealInfoOpt))
+
+IF(PRESENT(IntInfoOpt))THEN
+  IntInfo=IntInfoOpt
+ELSE
+  IntInfo=999
+END IF
+
+IF(PRESENT(RealInfoOpt))THEN
+  RealInfo=RealInfoOpt
+ELSE
+  RealInfo=999.
+END IF
+
 WRITE(UNIT_stdOut,*)
 WRITE(UNIT_stdOut,*)'_____________________________________________________________________________'
 WRITE(UNIT_stdOut,*)'Program abort caused in File : ',TRIM(SourceFile),' Line ',SourceLine

--- a/src/mesh/mesh.f90
+++ b/src/mesh/mesh.f90
@@ -395,7 +395,7 @@ END IF !PostDeform
 ConformConnect=GETLOGICAL('ConformConnect','.TRUE.') ! Fast connect for conform mesh
 
 ! build connect of edges and vertices:
-generateFEMconnectivity=GETLOGICAL('generateFEMconnectivity','.FALSE.') 
+generateFEMconnectivity=GETLOGICAL('generateFEMconnectivity','.FALSE.')
 ! Elem Check
 checkElemJacobians=GETLOGICAL('checkElemJacobians','.TRUE.')
 jacobianTolerance=GETREAL('jacobianTolerance','1.E-16')
@@ -789,7 +789,6 @@ IF(mortarFound) THEN
 END IF !mortarFound
 
 ! apply meshscale before output (default)
-IF(doScale.AND.postScale) CALL ApplyMeshScale(FirstElem)
 IF( (doShift.AND.postShift) .OR. (doScale.AND.postScale) ) THEN
   CALL ApplyMeshScale(FirstElem, doMeshScale=(doScale.AND.postScale), doMeshShift=(doShift.AND.postShift))
 END IF

--- a/src/mesh/mesh_basis.f90
+++ b/src/mesh/mesh_basis.f90
@@ -121,7 +121,7 @@ SUBROUTINE ElemGeometry(Elem,TrafoOpt,TrafoInvOpt)
 !===================================================================================================================================
 ! Compute the (linear) transformation for each element to its reference element.
 ! This linear transformation starts always from the first element node x_1!!
-! Tranfsormation matrix (jacobi matrix)+Inverse of this mapping and Jacobi determinand of this mapping are computed.
+! Transformation matrix (jacobi matrix)+Inverse of this mapping and Jacobi determinand of this mapping are computed.
 !===================================================================================================================================
 ! MODULES
 USE MOD_Mesh_Vars,ONLY:tElem,tSide,tSidePtr,tBC,tNode,N,jacobianTolerance
@@ -190,7 +190,7 @@ IF(Elem%detT .LE. jacobianTolerance)THEN
   Trafo(:,2)=v1
   CALL INV33(Trafo,TrafoInv,Elem%detT)
   IF(Elem%detT .LE. jacobianTolerance)&
-    CALL abort(__STAMP__,'Element with null-negative detT found! Elem%ind: ',Elem%ind)
+    CALL abort(__STAMP__,'Element with null-negative detT found. Try changing the jacobianTolerance parameter!')
 
   ! Element has wrong orientation rotate it into right-handed system
   Side=>Elem%firstSide
@@ -801,19 +801,19 @@ SUBROUTINE buildFEMconnectivity()
 ! Fill the FEM edge and Vertex connectivity as a pointer datastructure:
 ! We already have unique pointers for geometric "nodes" and geometric "edges" (buildEdges needed before calling this routine!)
 ! If periodic BCs are present, its important that a "FEM vertex" and a "FEM edge"=`LocalEdge` are unique in a topological sense,
-! which is different to the geometrical uniqueness. 
-! For example, a 1 element fully periodic domain has 8 unique nodes, but only one FEM vertex, 
-! and it has 12 unique edges geometrically, but only 3 FEM edges (3 x (4 geometric edges)). 
+! which is different to the geometrical uniqueness.
+! For example, a 1 element fully periodic domain has 8 unique nodes, but only one FEM vertex,
+! and it has 12 unique edges geometrically, but only 3 FEM edges (3 x (4 geometric edges)).
 !
-! FEM  connectivity means that each geometric entity (vertex/edge) of an element needs to have a list of all elements 
+! FEM  connectivity means that each geometric entity (vertex/edge) of an element needs to have a list of all elements
 ! which are connected via that entity. There is only one geometric entity  that "owns" this list (=master edge/vertex),
 ! which is then accessed via the `FirstLocalEdge`/`FirstVertex` pointer (not associated for "slave" entities).
-! In this list, there is then a `nextEdge`/`nextVertex` pointer, 
+! In this list, there is then a `nextEdge`/`nextVertex` pointer,
 ! and the number of connections is counted in the `FirstLocalEdge%tmp`/`FirstVertex%tmp`.
 ! First we loop through all element sides which have a periodic neighbor, where we use
 ! the `orientedNodes` to access the neighbors edges and vertices, and add their connection to the pointer list.
 ! Then we loop through all sides again to fill the remaining edge and vertex connectivity into the pointer list.
-! The pointer datastructure will be translated into the hdf5 meshfile data in "WriteMeshToHDF5" routine. 
+! The pointer datastructure will be translated into the hdf5 meshfile data in "WriteMeshToHDF5" routine.
 !===================================================================================================================================
 ! MODULES
   USE MOD_Mesh_Vars,ONLY:tElem,tSide,tEdge,tNode,tEdgePtr,tLocalEdge,tVertex

--- a/src/mesh/mesh_connect.f90
+++ b/src/mesh/mesh_connect.f90
@@ -13,7 +13,7 @@
 ! Copyright (C) 2017 Claus-Dieter Munz <munz@iag.uni-stuttgart.de>
 ! This file is part of HOPR, a software for the generation of high-order meshes.
 !
-! HOPR is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License 
+! HOPR is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
 ! as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
 !
 ! HOPR is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
@@ -32,12 +32,12 @@ USE MOD_Globals
 IMPLICIT NONE
 PRIVATE
 !-----------------------------------------------------------------------------------------------------------------------------------
-! GLOBAL VARIABLES 
+! GLOBAL VARIABLES
 !-----------------------------------------------------------------------------------------------------------------------------------
 ! Private Part ---------------------------------------------------------------------------------------------------------------------
 ! Public Part ----------------------------------------------------------------------------------------------------------------------
 INTERFACE Connect
-  MODULE PROCEDURE Connect 
+  MODULE PROCEDURE Connect
 END INTERFACE
 
 INTERFACE Connect2DMesh
@@ -81,7 +81,7 @@ LOGICAL,INTENT(IN)        :: deletePeriodic
 !-----------------------------------------------------------------------------------------------------------------------------------
 ! OUTPUT VARIABLES
 !-----------------------------------------------------------------------------------------------------------------------------------
-! LOCAL VARIABLES 
+! LOCAL VARIABLES
 TYPE(tElem),POINTER       :: Elem                                                       ! Local element pointers
 TYPE(tSide),POINTER       :: Side                                                       ! Local side pointers
 TYPE(tSide),POINTER       :: pSide  ! ?
@@ -154,16 +154,16 @@ DO WHILE(ASSOCIATED(Elem))
         !build a dummy side as connection
         Side%tmp2=Side%BC%BCalphaInd  ! vv +/-1 as info and marker for dummy side
         IF(Side%tmp2.GT.0)THEN ! side with positive vv is the master and gets the dummy side
-          CALL getNewSide(pSide,Side%nNodes)  
+          CALL getNewSide(pSide,Side%nNodes)
           DO iNode=1,Side%nNodes
             CALL getNewNode(pSide%Node(iNode)%np)
-            pSide%Node(iNode)%np%x  =Side%Node(iNode)%np%x + VV(:,ABS(Side%tmp2)) 
+            pSide%Node(iNode)%np%x  =Side%Node(iNode)%np%x + VV(:,ABS(Side%tmp2))
             ! Ind of dummy node MUST be negative or zero:
             ! these nodes are duplicate and globaluniquenode uses biggest ind for duplicates
             pSide%Node(iNode)%np%ind=-Side%Node(iNode)%np%ind
           END DO
           pSide%elem=>side%elem
-          side%connection=>pSide 
+          side%connection=>pSide
         END IF
       END IF
     END IF
@@ -262,11 +262,11 @@ END SUBROUTINE Connect
 
 SUBROUTINE ConnectMesh()
 !===================================================================================================================================
-! Connect all sides which can be found by node association. Uses Quicksort 
+! Connect all sides which can be found by node association. Uses Quicksort
 !===================================================================================================================================
 ! MODULES
-USE MOD_Mesh_Vars, ONLY:tElem,tSide,tSidePtr,FirstElem,nInnerSides,nConformingSides
-USE MOD_Mesh_Vars, ONLY:deleteNode
+USE MOD_Mesh_Vars, ONLY:tElem,tSide,tSidePtr,FirstElem,nInnerSides,nConformingSides,MeshMode
+USE MOD_Mesh_Vars, ONLY:deleteNode,copyBC
 USE MOD_SortingTools,ONLY:Qsort1Int,Qsort4Int,MSortNInt
 ! IMPLICIT VARIABLE HANDLING
 IMPLICIT NONE
@@ -275,7 +275,7 @@ IMPLICIT NONE
 !-----------------------------------------------------------------------------------------------------------------------------------
 ! OUTPUT VARIABLES
 !-----------------------------------------------------------------------------------------------------------------------------------
-! LOCAL VARIABLES 
+! LOCAL VARIABLES
 TYPE(tElem),POINTER       :: Elem                                                       ! Local element pointers
 TYPE(tSide),POINTER       :: Side,nSide                                               ! Local side pointers
 TYPE(tSidePtr),POINTER    :: InnerSides(:)   ! ?
@@ -304,7 +304,7 @@ DO WHILE(ASSOCIATED(Elem))
       nInnerSides=nInnerSides+1
       Side%tmp=nInnerSides  !"SideID"
       DO iNode=1,Side%nNodes
-        Side%Node(iNode)%np%tmp=0 
+        Side%Node(iNode)%np%tmp=0
       END DO
     ELSE
       !adjust oriented nodes for BCs
@@ -317,7 +317,7 @@ DO WHILE(ASSOCIATED(Elem))
       nInnerSides=nInnerSides+1
       Side%tmp=nInnerSides  !"SideID"
       DO iNode=1,Side%nNodes
-        Side%connection%Node(iNode)%np%tmp=0 !use dummy nodes! 
+        Side%connection%Node(iNode)%np%tmp=0 !use dummy nodes!
       END DO
     END IF
     Side=>Side%nextElemSide
@@ -329,7 +329,7 @@ ALLOCATE(InnerSides(nInnerSides))
 DO iSide=1,nInnerSides
   NULLIFY(InnerSides(iSide)%sp)
 END DO
-ALLOCATE(SideConnect(5,nInnerSides)) 
+ALLOCATE(SideConnect(5,nInnerSides))
 SideConnect=0
 ! make a list of innersides and set unique node IDs (%np%tmp)
 ! and make a list of side node ids (SideConnect(iSide,:)1:4 --> nodeids, 5: SideID
@@ -369,7 +369,7 @@ DO WHILE(ASSOCIATED(Elem))
       iSide=Side%tmp
       !put into side list
       InnerSides(iSide)%sp=>Side
-      !Set Unique node IDs of periodic side dummy !! 
+      !Set Unique node IDs of periodic side dummy !!
       DO iNode=1,Side%nNodes
         IF(Side%connection%Node(iNode)%np%tmp.EQ.0)THEN
           NodeID=NodeID+1
@@ -396,7 +396,7 @@ DO iSide=1,nInnerSides-1
   IF(ASSOCIATED(Side%Connection).AND.(Side%tmp2.EQ.0)) CYCLE ! already connected side
   ! now compare Side Node IDs
   IF(SUM(ABS(SideConnect(1:4,iSide+1)-SideConnect(1:4,iSide))).EQ.0)THEN
-    ! Side connection found 
+    ! Side connection found
     counter=counter+2
     nSide=>InnerSides(SideConnect(5,iSide+1))%sp
 
@@ -407,7 +407,7 @@ DO iSide=1,nInnerSides-1
       END DO
       IF(fNode.EQ.0)CALL abort(__STAMP__,'Problem with OrientedNode !')
     ELSEIF(Side%tmp2.LT.0) THEN !only connect from periodic slave side to master side (->nSide has a dummy connection side)
-      ! for adjustorientednodes by pointer association (no tolerance gedoens!) 
+      ! for adjustorientednodes by pointer association (no tolerance gedoens!)
       fNode=0
       DO iNode=1,Side%nNodes
         IF(ASSOCIATED(Side%Node(1)%np,nSide%connection%Node(iNode)%np)) fNode=iNode
@@ -437,7 +437,33 @@ DO iSide=1,nInnerSides-1
     !set connection
     nSide%connection=>Side
     Side%connection=>nSide
-    !adjustorientednodes 
+    ! Inner BC: Sanity check for internal meshes and fix for cubit meshes
+    IF(ASSOCIATED(Side%BC)) THEN
+      ! Check if the current side is an inner BC
+      IF(Side%BC%BCType.EQ.100) THEN
+        ! Check if the connected side has a BC
+        IF(.NOT.ASSOCIATED(nSide%BC)) THEN
+          ! In case of a gambit import (currently used for cubit meshes), copy the BC to the connected side
+          IF(MeshMode.EQ.2) THEN
+            CALL copyBC(Side,nSide)
+          ELSE
+            CALL abort(__STAMP__,' Internal mesh: Error in boundary condition definition, inner BC points to an inner side! BC Index: ', IntInfoOpt=Side%BC%BCIndex)
+          END IF
+        ELSE IF(nSide%BC%BCType.NE.100) THEN
+          CALL abort(__STAMP__,' Error in boundary condition definition, inner BC is connected to another BC!', IntInfoOpt=nSide%BC%BCIndex)
+        END IF
+      END IF
+    ELSE IF(ASSOCIATED(nSide%BC)) THEN
+      ! Same check for the connected side, since it will be cycled after the connection is set
+      IF(nSide%BC%BCType.EQ.100) THEN
+        IF(MeshMode.EQ.2) THEN
+          CALL copyBC(nSide,Side)
+        ELSE
+          CALL abort(__STAMP__,' Internal mesh: Error in boundary condition definition, inner BC points to an inner side! BC Index: ', IntInfoOpt=nSide%BC%BCIndex)
+        END IF
+      END IF
+    END IF
+    !adjustorientednodes
     dominant=(Side%Elem%ind .LT. nSide%Elem%ind)
     IF(dominant) THEN
       DO iNode=1,nSide%nNodes
@@ -468,7 +494,7 @@ END SUBROUTINE ConnectMesh
 
 SUBROUTINE NonconformConnectMesh(reconnect)
 !===================================================================================================================================
-! Connect all non-conforming sides. 
+! Connect all non-conforming sides.
 ! This routine assumes that all conforming sides have already been connected and that all nodes in the mesh are unique.
 !===================================================================================================================================
 ! MODULES
@@ -484,7 +510,7 @@ LOGICAL,INTENT(IN)        :: reconnect
 !-----------------------------------------------------------------------------------------------------------------------------------
 ! OUTPUT VARIABLES
 !-----------------------------------------------------------------------------------------------------------------------------------
-! LOCAL VARIABLES 
+! LOCAL VARIABLES
 TYPE(tElem),POINTER       :: Elem                                                       ! Local element pointers
 TYPE(tSide),POINTER       :: Side,dummySide
 TYPE(tSide),POINTER       :: aSide,bSide,smallSide1,smallSide2,bigSide,tmpSide
@@ -510,7 +536,7 @@ LOGICAL                   :: aFoundEdge(4),bFoundEdge(4),aFoundNode(4)
 ! first count and collect all unconnected sides
 CGNSToCart=(/1,2,4,3/)
 
-! count number of unconnected (potetially non-conforming) sides
+! count number of unconnected (potentially non-conforming) sides
 nNonConformingSides=0
 Elem=>FirstElem
 DO WHILE(ASSOCIATED(Elem))
@@ -695,7 +721,7 @@ DO iSide=1,nNonConformingSides-2
           ind=MAXLOC(edgeLen,1)
           bigSide=>trio(ind)%sp; smallSide1=>trio(next1(ind,3))%sp; smallSide2=>trio(next2(ind,3))%sp
         END IF
-        
+
         ! check which edges of big and small side are identical to determine the mortar type (wheter mortar is in
         !  xi or eta direction), then set the connection
         CALL CommonEdge(bigSide,smallSide1,aFoundEdge)
@@ -728,7 +754,7 @@ DO iSide=1,nNonConformingSides-2
         smallSide2%connection=>bigSide
         smallSide1%MortarType=-bigSide%MortarType
         smallSide2%MortarType=-bigSide%MortarType
-        
+
         SideDone(bigSide%tmp)=.TRUE.
         SideDone(smallSide1%tmp)=.TRUE.
         SideDone(smallSide2%tmp)=.TRUE.
@@ -738,7 +764,7 @@ DO iSide=1,nNonConformingSides-2
   END DO
 END DO
 
-! Find 4->1 interfaces: 
+! Find 4->1 interfaces:
 ! We assume that only sides belonging to a 4-> mortar interface are left in the sidelist
 ! At 4->1 interfaces the center node has exactly 4 neighbour sides, while all other nodes have
 ! more neighbour sides. We want to find the nodes with exactly 4 neighbour sides
@@ -772,7 +798,7 @@ DO iSide=1,nNonConformingSides
   IF(ANY(nFound.EQ.0)) CYCLE
 
   DO kSide=1,nFound(1)
-    checkInd=foundSides(2,kSide,1) 
+    checkInd=foundSides(2,kSide,1)
     bigCorner(1)=foundSides(1,kSide,1)
     bigCorner(2:4)=0
     DO iNode=2,4
@@ -935,7 +961,7 @@ TYPE(tSide),POINTER,INTENT(IN) :: aSide
 !-----------------------------------------------------------------------------------------------------------------------------------
 ! OUTPUT VARIABLES
 !-----------------------------------------------------------------------------------------------------------------------------------
-! LOCAL VARIABLES 
+! LOCAL VARIABLES
 TYPE(tSide),POINTER       :: bSide
 INTEGER                   :: iNode,jNode,jSide  ! ?
 INTEGER                   :: masterNode,slaveNode
@@ -948,7 +974,7 @@ DO iNode=1,aSide%nNodes
 END DO
 ! small sides
 DO jSide=1,aSide%nMortars
-  bSide=>aSide%MortarSide(jSide)%sp 
+  bSide=>aSide%MortarSide(jSide)%sp
   commonNode=.FALSE.
   DO iNode=1,aSide%nNodes
     DO jNode=1,bSide%nNodes
@@ -987,7 +1013,7 @@ INTEGER,INTENT(IN)                   :: nA,nB
 LOGICAL,INTENT(OUT)                  :: aFoundEdge(4)
 LOGICAL,INTENT(OUT),OPTIONAL         :: aFoundNode(4)
 !-----------------------------------------------------------------------------------------------------------------------------------
-! LOCAL VARIABLES 
+! LOCAL VARIABLES
 LOGICAL                              :: tmp(4)
 INTEGER                              :: iNode,jNode  ! ?
 !===================================================================================================================================
@@ -1023,7 +1049,7 @@ TYPE(tSide),POINTER,INTENT(IN)       :: aSide,bSide
 ! OUTPUT VARIABLES
 LOGICAL,INTENT(OUT)                  :: aFoundEdge(4)
 !-----------------------------------------------------------------------------------------------------------------------------------
-! LOCAL VARIABLES 
+! LOCAL VARIABLES
 LOGICAL                              :: aFoundNode(4)
 INTEGER                              :: iNode,jNode  ! ?
 !===================================================================================================================================
@@ -1059,13 +1085,13 @@ TYPE(tElem),POINTER,INTENT(IN)       :: aElem,bElem
 ! OUTPUT VARIABLES
 INTEGER,INTENT(OUT)                  :: aLocSide,bLocSide
 !-----------------------------------------------------------------------------------------------------------------------------------
-! LOCAL VARIABLES 
+! LOCAL VARIABLES
 TYPE(tSide),POINTER                  :: aSide,bSide
 !===================================================================================================================================
 aLocSide=0
 aSide=>aElem%firstSide
 DO WHILE(ASSOCIATED(aSide))
-  aLocSide=aLocSide+1 
+  aLocSide=aLocSide+1
   bLocSide=0
   bSide=>bElem%firstSide
   DO WHILE(ASSOCIATED(bSide))
@@ -1098,7 +1124,7 @@ END SUBROUTINE CommonElementSide
 
 SUBROUTINE Connect2DMesh(firstElem_in)
 !===================================================================================================================================
-! Connect all side edges (2D) which can be found by node association. Uses Quicksort 
+! Connect all side edges (2D) which can be found by node association. Uses Quicksort
 !===================================================================================================================================
 ! MODULES
 USE MOD_Mesh_Vars, ONLY:tElem,tSide,tSidePtr
@@ -1111,7 +1137,7 @@ TYPE(tElem),POINTER,INTENT(IN)       :: FirstElem_in   ! ?
 !-----------------------------------------------------------------------------------------------------------------------------------
 ! OUTPUT VARIABLES
 !-----------------------------------------------------------------------------------------------------------------------------------
-! LOCAL VARIABLES 
+! LOCAL VARIABLES
 INTEGER                :: i,iSide,nEdges  ! ?
 TYPE(tElem),POINTER    :: aElem   ! ?
 TYPE(tSide),POINTER    :: aSide   ! ?
@@ -1123,7 +1149,7 @@ aElem=>firstElem_in
 DO WHILE(ASSOCIATED(aElem))
   nEdges=nEdges+aElem%nNodes
   aElem=>aElem%nextElem
-END DO  
+END DO
 
 !build up connect, new style!!
 ALLOCATE(Edges(nEdges),EdgeConnect(nEdges,3))
@@ -1144,7 +1170,7 @@ DO WHILE(ASSOCIATED(aElem))
     aSide=>aSide%nextElemSide
   END DO
   aElem=>aElem%nextElem
-END DO  
+END DO
 CALL Qsort2Int(EdgeConnect)
 ! only local 2D connect is needed
 DO iSide=2,nEdges

--- a/src/mesh/splittohex.f90
+++ b/src/mesh/splittohex.f90
@@ -13,7 +13,7 @@
 ! Copyright (C) 2017 Claus-Dieter Munz <munz@iag.uni-stuttgart.de>
 ! This file is part of HOPR, a software for the generation of high-order meshes.
 !
-! HOPR is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License 
+! HOPR is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
 ! as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
 !
 ! HOPR is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
@@ -32,7 +32,7 @@ USE MOD_Globals
 IMPLICIT NONE
 PRIVATE
 !-----------------------------------------------------------------------------------------------------------------------------------
-! GLOBAL VARIABLES 
+! GLOBAL VARIABLES
 !-----------------------------------------------------------------------------------------------------------------------------------
 ! Private Part ---------------------------------------------------------------------------------------------------------------------
 ! Public Part ----------------------------------------------------------------------------------------------------------------------
@@ -60,7 +60,6 @@ SUBROUTINE SplitAllHexa(nFine)
 USE MOD_Globals
 USE MOD_Mesh_Vars, ONLY:tElem,FirstElem
 USE MOD_Mesh_Vars, ONLY:useCurveds
-USE MOD_Mesh_Basis,ONLY:ElemGeometry
 ! IMPLICIT VARIABLE HANDLING
 IMPLICIT NONE
 !-----------------------------------------------------------------------------------------------------------------------------------
@@ -69,7 +68,7 @@ INTEGER,INTENT(IN)            :: nFine  ! ?
 !-----------------------------------------------------------------------------------------------------------------------------------
 ! OUTPUT VARIABLES
 !-----------------------------------------------------------------------------------------------------------------------------------
-! LOCAL VARIABLES 
+! LOCAL VARIABLES
 TYPE(tElem),POINTER           :: Elem  ! ?
 INTEGER                       :: maxInd,ii  ! ?
 !===================================================================================================================================
@@ -93,7 +92,7 @@ maxInd=0
 Elem=>firstElem      !get maxInd of nodes
 DO WHILE(ASSOCIATED(Elem))
   DO ii=1,Elem%nNodes
-    IF(Elem%node(ii)%np%ind.GT.maxInd) maxInd=Elem%node(ii)%np%ind 
+    IF(Elem%node(ii)%np%ind.GT.maxInd) maxInd=Elem%node(ii)%np%ind
   END DO
   Elem=>Elem%nextElem
 ENDDO
@@ -114,7 +113,6 @@ USE MOD_Globals
 USE MOD_Mesh_Vars, ONLY:tElem,FirstElem
 USE MOD_Mesh_Vars, ONLY:useCurveds
 USE MOD_Mesh_Vars, ONLY:nSplitBoxes,SplitBoxes
-USE MOD_Mesh_Basis,ONLY:ElemGeometry
 ! IMPLICIT VARIABLE HANDLING
 IMPLICIT NONE
 !-----------------------------------------------------------------------------------------------------------------------------------
@@ -122,9 +120,9 @@ IMPLICIT NONE
 !-----------------------------------------------------------------------------------------------------------------------------------
 ! OUTPUT VARIABLES
 !-----------------------------------------------------------------------------------------------------------------------------------
-! LOCAL VARIABLES 
-TYPE(tElem),POINTER           :: Elem  
-INTEGER                       :: maxInd,ii,iBox 
+! LOCAL VARIABLES
+TYPE(tElem),POINTER           :: Elem
+INTEGER                       :: maxInd,ii,iBox
 REAL                          :: xBary(3)
 !===================================================================================================================================
 CALL Timer(.TRUE.)
@@ -149,7 +147,7 @@ DO iBox=1,nSplitBoxes
   Elem=>firstElem      !get maxInd of nodes
   DO WHILE(ASSOCIATED(Elem))
     DO ii=1,Elem%nNodes
-      IF(Elem%node(ii)%np%ind.GT.maxInd) maxInd=Elem%node(ii)%np%ind 
+      IF(Elem%node(ii)%np%ind.GT.maxInd) maxInd=Elem%node(ii)%np%ind
     END DO
     Elem=>Elem%nextElem
   ENDDO
@@ -174,13 +172,12 @@ END SUBROUTINE SplitHexaByBoxes
 
 SUBROUTINE SplitElementsToHex()
 !===================================================================================================================================
-! call routines to split tetra, prism and hexa to hexas. no pyramids allowed!! 
+! call routines to split tetra, prism and hexa to hexas. no pyramids allowed!!
 !===================================================================================================================================
 ! MODULES
 USE MOD_Globals
 USE MOD_Mesh_Vars, ONLY:tElem,FirstElem
 USE MOD_Mesh_Vars, ONLY:useCurveds
-USE MOD_Mesh_Basis,ONLY:ElemGeometry
 ! IMPLICIT VARIABLE HANDLING
 IMPLICIT NONE
 !-----------------------------------------------------------------------------------------------------------------------------------
@@ -188,7 +185,7 @@ IMPLICIT NONE
 !-----------------------------------------------------------------------------------------------------------------------------------
 ! OUTPUT VARIABLES
 !-----------------------------------------------------------------------------------------------------------------------------------
-! LOCAL VARIABLES 
+! LOCAL VARIABLES
 TYPE(tElem),POINTER           :: Elem  ! ?
 INTEGER                       :: maxInd,ii,counter(3)  ! ?
 !===================================================================================================================================
@@ -201,7 +198,7 @@ IF(useCurveds) CALL abort(__STAMP__,'SplitToHex cannot be used with curved eleme
 Elem=>firstElem      !get maxInd of nodes
 DO WHILE(ASSOCIATED(Elem))
   DO ii=1,Elem%nNodes
-    IF(Elem%node(ii)%np%ind.GT.maxInd) maxInd=Elem%node(ii)%np%ind 
+    IF(Elem%node(ii)%np%ind.GT.maxInd) maxInd=Elem%node(ii)%np%ind
   END DO
   Elem=>Elem%nextElem
 ENDDO
@@ -249,7 +246,7 @@ INTEGER, INTENT(IN)            :: M    ! number of elements to refine
 ! OUTPUT VARIABLES
 INTEGER,INTENT(INOUT)          :: maxInd  ! ?
 !-----------------------------------------------------------------------------------------------------------------------------------
-! LOCAL VARIABLES 
+! LOCAL VARIABLES
 TYPE(tElem),POINTER       :: aElem,nextElem,prevElem  ! ?
 TYPE(tSide),POINTER       :: Side
 TYPE(tElemPtr)            :: NewElems(0:M-1,0:M-1,0:M-1)  ! ?
@@ -274,23 +271,23 @@ DO i=0,M,M ; DO j=0,M,M; DO l=1,M-1
   CALL GetNewNode(NewNodes(l,i,j)%np,ind=maxInd)
   CALL GetNewNode(NewNodes(i,l,j)%np,ind=maxInd)
   CALL GetNewNode(NewNodes(i,j,l)%np,ind=maxInd)
-  NewNodes(l,i,j)%np%x=sM*(REAL(M-l)*NewNodes(0,i,j)%np%x + REAL(l)*NewNodes(M,i,j)%np%x) 
-  NewNodes(i,l,j)%np%x=sM*(REAL(M-l)*NewNodes(i,0,j)%np%x + REAL(l)*NewNodes(i,M,j)%np%x) 
-  NewNodes(i,j,l)%np%x=sM*(REAL(M-l)*NewNodes(i,j,0)%np%x + REAL(l)*NewNodes(i,j,M)%np%x) 
+  NewNodes(l,i,j)%np%x=sM*(REAL(M-l)*NewNodes(0,i,j)%np%x + REAL(l)*NewNodes(M,i,j)%np%x)
+  NewNodes(i,l,j)%np%x=sM*(REAL(M-l)*NewNodes(i,0,j)%np%x + REAL(l)*NewNodes(i,M,j)%np%x)
+  NewNodes(i,j,l)%np%x=sM*(REAL(M-l)*NewNodes(i,j,0)%np%x + REAL(l)*NewNodes(i,j,M)%np%x)
 END DO; END DO; END DO
 ! midnodes at faces
-DO i=0,M,M; DO k=1,M-1; DO l=1,M-1 
+DO i=0,M,M; DO k=1,M-1; DO l=1,M-1
   CALL GetNewNode(NewNodes(i,k,l)%np,ind=maxInd)
   CALL GetNewNode(NewNodes(k,i,l)%np,ind=maxInd)
   CALL GetNewNode(NewNodes(k,l,i)%np,ind=maxInd)
-  NewNodes(i,k,l)%np%x=sM*(REAL(M-k)*NewNodes(i,0,l)%np%x + REAL(k)*NewNodes(i,M,l)%np%x) 
-  NewNodes(k,i,l)%np%x=sM*(REAL(M-k)*NewNodes(0,i,l)%np%x + REAL(k)*NewNodes(M,i,l)%np%x) 
-  NewNodes(k,l,i)%np%x=sM*(REAL(M-k)*NewNodes(0,l,i)%np%x + REAL(k)*NewNodes(M,l,i)%np%x) 
+  NewNodes(i,k,l)%np%x=sM*(REAL(M-k)*NewNodes(i,0,l)%np%x + REAL(k)*NewNodes(i,M,l)%np%x)
+  NewNodes(k,i,l)%np%x=sM*(REAL(M-k)*NewNodes(0,i,l)%np%x + REAL(k)*NewNodes(M,i,l)%np%x)
+  NewNodes(k,l,i)%np%x=sM*(REAL(M-k)*NewNodes(0,l,i)%np%x + REAL(k)*NewNodes(M,l,i)%np%x)
 END DO; END DO; END DO
 ! inner element nodes
-DO i=1,M-1; DO j=1,M-1; DO k=1,M-1 
+DO i=1,M-1; DO j=1,M-1; DO k=1,M-1
   CALL GetNewNode(NewNodes(i,j,k)%np,ind=maxInd)
-  NewNodes(i,j,k)%np%x=sM*(REAL(M-i)*NewNodes(0,j,k)%np%x + REAL(i)*NewNodes(M,j,k)%np%x) 
+  NewNodes(i,j,k)%np%x=sM*(REAL(M-i)*NewNodes(0,j,k)%np%x + REAL(i)*NewNodes(M,j,k)%np%x)
 END DO; END DO; END DO;
 
 !build new elements
@@ -377,7 +374,7 @@ TYPE(tElem),POINTER,INTENT(INOUT)            :: Elem  ! ?
 ! OUTPUT VARIABLES
 INTEGER,INTENT(INOUT)          :: maxInd  ! ?
 !-----------------------------------------------------------------------------------------------------------------------------------
-! LOCAL VARIABLES 
+! LOCAL VARIABLES
 TYPE(tElem),POINTER       :: aElem,nextElem,prevElem  ! ?
 TYPE(tSide),POINTER       :: Side  ! ?
 TYPE(tSidePtr)            :: NewSides(4,6)  ! ?
@@ -517,7 +514,7 @@ INTEGER, INTENT(IN)            :: M    ! number of elements to refine zeta direc
 ! OUTPUT VARIABLES
 INTEGER,INTENT(INOUT)          :: maxInd  ! ?
 !-----------------------------------------------------------------------------------------------------------------------------------
-! LOCAL VARIABLES 
+! LOCAL VARIABLES
 TYPE(tElem),POINTER       :: aElem,nextElem,prevElem  ! ?
 TYPE(tSide),POINTER       :: Side  ! ?
 TYPE(tElemPtr)            :: NewElems(3,0:M-1)  ! ?
@@ -549,7 +546,7 @@ END DO
 DO l=1,M-1
   DO i=1,7
     CALL GetNewNode(NewNodes(i,l)%np,ind=maxInd)
-    NewNodes(i,l)%np%x=sM*(REAL(M-l)*NewNodes(i,0)%np%x + REAL(l)*NewNodes(i,M)%np%x) 
+    NewNodes(i,l)%np%x=sM*(REAL(M-l)*NewNodes(i,0)%np%x + REAL(l)*NewNodes(i,M)%np%x)
   END DO
 END DO
 

--- a/src/readin/readin_gambit.f90
+++ b/src/readin/readin_gambit.f90
@@ -12,7 +12,7 @@
 ! Copyright (C) 2017 Claus-Dieter Munz <munz@iag.uni-stuttgart.de>
 ! This file is part of HOPR, a software for the generation of high-order meshes.
 !
-! HOPR is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License 
+! HOPR is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
 ! as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
 !
 ! HOPR is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
@@ -31,7 +31,7 @@ USE MOD_Globals
 IMPLICIT NONE
 PRIVATE
 !-----------------------------------------------------------------------------------------------------------------------------------
-! GLOBAL VARIABLES 
+! GLOBAL VARIABLES
 !-----------------------------------------------------------------------------------------------------------------------------------
 ! Private Part ---------------------------------------------------------------------------------------------------------------------
 ! Public Part ----------------------------------------------------------------------------------------------------------------------
@@ -66,7 +66,7 @@ IMPLICIT NONE
 !-----------------------------------------------------------------------------------------------------------------------------------
 ! OUTPUT VARIABLES
 !-----------------------------------------------------------------------------------------------------------------------------------
-! LOCAL VARIABLES 
+! LOCAL VARIABLES
 TYPE(tNode),POINTER    :: actualNode   ! ?
 TYPE(tElem),POINTER    :: actualElem  ! ?
 TYPE(tSide),POINTER    :: aSide   ! ?
@@ -138,7 +138,7 @@ DO iFile=1,nMeshFiles
       READ(104,*)dummy1,nodeCoords(1:meshDim,iNode)
     END DO
     DO i = 1, 2                                                               ! Header weglesen
-      READ(104,*)                                                             
+      READ(104,*)
     END DO
   END IF ! useBinary
   ! Read elements
@@ -152,7 +152,7 @@ DO iFile=1,nMeshFiles
   END IF
   ! Read element connectivity
   ALLOCATE(iDummyArray2(nElems,10),iDummyArray3(nElems))
-  IF(useBinary)THEN 
+  IF(useBinary)THEN
     READ(104)iDummyArray2
     READ(104)iDummyArray3
   ELSE
@@ -202,8 +202,8 @@ DO iFile=1,nMeshFiles
   END DO
   actualElem=>firstElem
   DO WHILE(ASSOCIATED(actualElem))
-    IF (actualElem%ind .GT.0) THEN 
-      elems(actualElem%ind)%ep=>actualElem 
+    IF (actualElem%ind .GT.0) THEN
+      elems(actualElem%ind)%ep=>actualElem
     END IF
     actualElem=>actualElem%nextElem
   END DO
@@ -211,7 +211,7 @@ DO iFile=1,nMeshFiles
   DO iZone = 1, nZones
     iGlZone=iGlZone+1
     IF (iGlZone .GT. nZones) &
-      CALL abort(__STAMP__,'inconsistent numer of Zones in readGambit',999,999.)
+      CALL abort(__STAMP__,'inconsistent number of Zones in readGambit',999,999.)
     IF(useBinary)THEN
       READ(104) dummy1
     ELSE
@@ -252,7 +252,7 @@ DO iFile=1,nMeshFiles
       DO i = 1, 2                                                                        ! Header weglesen
         READ(104,*)
       END DO
-      READ(104,'(A255)') strBC                                                         ! Read line    
+      READ(104,'(A255)') strBC                                                         ! Read line
     END IF ! useBinary
     foundBC=.FALSE.
     DO i=1,nUserDefinedBoundaries
@@ -261,7 +261,7 @@ DO iFile=1,nMeshFiles
         strBCName=TRIM(ADJUSTL(strBC(1:dummy1+LEN(TRIM(BoundaryName(i))))))  ! Get the boundary name
         ! Check if it is really the same BC and not a partial match
         IF(TRIM(strBCName).NE.TRIM(BoundaryName(i))) CYCLE
-        foundBC=.TRUE. 
+        foundBC=.TRUE.
         BCType     = BoundaryType(i,1)
         curveIndex = BoundaryType(i,2)
         BCState    = BoundaryType(i,3)

--- a/tutorials/2-08-external_mesh_Gambit_ASCII/export.neu
+++ b/tutorials/2-08-external_mesh_Gambit_ASCII/export.neu
@@ -1,0 +1,139 @@
+        CONTROL INFO 2.4.6
+** GAMBIT NEUTRAL FILE
+FILEPATH
+PROGRAM:        Coreform_Cubit     VERSION:  2024.3
+
+     NUMNP     NELEM     NGRPS    NBSETS     NDFCD     NDFVL
+        27         8         2         7         3         3
+ENDOFSECTION
+   NODAL COORDINATES 2.4.6
+         1   0.00000000000e+00   0.00000000000e+00   0.00000000000e+00
+         2   0.00000000000e+00   0.00000000000e+00   5.00000000000e-01
+         3   5.00000000000e-01   0.00000000000e+00   5.00000000000e-01
+         4   5.00000000000e-01   0.00000000000e+00   0.00000000000e+00
+         5   0.00000000000e+00   5.00000000000e-01   0.00000000000e+00
+         6   0.00000000000e+00   5.00000000000e-01   5.00000000000e-01
+         7   5.00000000000e-01   5.00000000000e-01   5.00000000000e-01
+         8   5.00000000000e-01   5.00000000000e-01   0.00000000000e+00
+         9   0.00000000000e+00   0.00000000000e+00   1.00000000000e+00
+        10   5.00000000000e-01   0.00000000000e+00   1.00000000000e+00
+        11   0.00000000000e+00   5.00000000000e-01   1.00000000000e+00
+        12   5.00000000000e-01   5.00000000000e-01   1.00000000000e+00
+        13   1.00000000000e+00   0.00000000000e+00   5.00000000000e-01
+        14   1.00000000000e+00   0.00000000000e+00   0.00000000000e+00
+        15   1.00000000000e+00   5.00000000000e-01   5.00000000000e-01
+        16   1.00000000000e+00   5.00000000000e-01   0.00000000000e+00
+        17   1.00000000000e+00   0.00000000000e+00   1.00000000000e+00
+        18   1.00000000000e+00   5.00000000000e-01   1.00000000000e+00
+        19   0.00000000000e+00   1.00000000000e+00   1.00000000000e+00
+        20   5.00000000000e-01   1.00000000000e+00   1.00000000000e+00
+        21   0.00000000000e+00   1.00000000000e+00   5.00000000000e-01
+        22   5.00000000000e-01   1.00000000000e+00   5.00000000000e-01
+        23   1.00000000000e+00   1.00000000000e+00   1.00000000000e+00
+        24   1.00000000000e+00   1.00000000000e+00   5.00000000000e-01
+        25   0.00000000000e+00   1.00000000000e+00   0.00000000000e+00
+        26   5.00000000000e-01   1.00000000000e+00   0.00000000000e+00
+        27   1.00000000000e+00   1.00000000000e+00   0.00000000000e+00
+ENDOFSECTION
+      ELEMENTS/CELLS 2.4.6
+       1  4  8        1       2       4       3       5       6       8
+                      7
+       2  4  8        2       9       3      10       6      11       7
+                     12
+       3  4  8        4       3      14      13       8       7      16
+                     15
+       4  4  8        3      10      13      17       7      12      15
+                     18
+       5  4  8       11      19      12      20       6      21       7
+                     22
+       6  4  8       12      20      18      23       7      22      15
+                     24
+       7  4  8        6      21       7      22       5      25       8
+                     26
+       8  4  8        7      22      15      24       8      26      16
+                     27
+ENDOFSECTION
+       ELEMENT GROUP 2.4.6
+GROUP:          1 ELEMENTS:          4 MATERIAL:          0 NFLAGS:          0
+                         Block 1
+
+
+       1       2       3       4
+ENDOFSECTION
+       ELEMENT GROUP 2.4.6
+GROUP:          2 ELEMENTS:          4 MATERIAL:          0 NFLAGS:          0
+                         Block 2
+
+
+       5       6       7       8
+ENDOFSECTION
+ BOUNDARY CONDITIONS 2.4.6
+                        BC_inner         1         4         0         6
+         3    4    6
+         1    4    6
+         4    4    6
+         2    4    6
+ENDOFSECTION
+ BOUNDARY CONDITIONS 2.4.6
+                       BC_yminus         1         4         0         6
+         2    4    5
+         1    4    5
+         4    4    5
+         3    4    5
+ENDOFSECTION
+ BOUNDARY CONDITIONS 2.4.6
+                       BC_xminus         1         4         0         6
+         7    4    1
+         5    4    1
+         2    4    1
+         1    4    1
+ENDOFSECTION
+ BOUNDARY CONDITIONS 2.4.6
+                       BC_zminus         1         4         0         6
+         8    4    6
+         7    4    6
+         1    4    4
+         3    4    4
+ENDOFSECTION
+ BOUNDARY CONDITIONS 2.4.6
+                        BC_xplus         1         4         0         6
+         3    4    3
+         4    4    3
+         6    4    3
+         8    4    3
+ENDOFSECTION
+ BOUNDARY CONDITIONS 2.4.6
+                        BC_yplus         1         4         0         6
+         6    4    2
+         8    4    2
+         5    4    2
+         7    4    2
+ENDOFSECTION
+ BOUNDARY CONDITIONS 2.4.6
+                        BC_zplus         1         4         0         6
+         4    4    2
+         2    4    2
+         5    4    5
+         6    4    5
+ENDOFSECTION
+ BOUNDARY CONDITIONS 2.4.6
+                        cfd_bc 1         1         0         0        51
+ENDOFSECTION
+ BOUNDARY CONDITIONS 2.4.6
+                        cfd_bc 2         1         0         0        51
+ENDOFSECTION
+ BOUNDARY CONDITIONS 2.4.6
+                        cfd_bc 3         1         0         0        51
+ENDOFSECTION
+ BOUNDARY CONDITIONS 2.4.6
+                        cfd_bc 4         1         0         0        51
+ENDOFSECTION
+ BOUNDARY CONDITIONS 2.4.6
+                        cfd_bc 5         1         0         0        51
+ENDOFSECTION
+ BOUNDARY CONDITIONS 2.4.6
+                        cfd_bc 6         1         0         0        51
+ENDOFSECTION
+ BOUNDARY CONDITIONS 2.4.6
+                        cfd_bc 7         1         0         0        51
+ENDOFSECTION

--- a/tutorials/2-08-external_mesh_Gambit_ASCII/hopr.ini
+++ b/tutorials/2-08-external_mesh_Gambit_ASCII/hopr.ini
@@ -1,0 +1,33 @@
+!=============================================================================== !
+! OUTPUT
+!=============================================================================== !
+ProjectName   =gambit_export               ! name of the project (used for filenames)
+Debugvisu     =T                           ! Write debug mesh to tecplot file
+Logging       =F                           ! Write log files
+!=============================================================================== !
+! MESH
+!=============================================================================== !
+Mode          =2                           ! 1 Cartesian 2 gambit file 3 CGNS
+FileName     = export.neu
+nMeshFiles   = 1                           ! number of meshfiles
+useCurveds    =F                           ! T if curved boundaries defined
+SpaceQuandt   =1.                          ! characteristic length of the mesh
+ConformConnect=F
+meshscale    = 0.001
+!=============================================================================== !
+! BOUNDARY CONDITIONS
+!=============================================================================== !
+BoundaryName=BC_xplus
+BoundaryType=(/4,0,0,0/)
+BoundaryName=BC_xminus
+BoundaryType=(/4,0,0,0/)
+BoundaryName=BC_yplus
+BoundaryType=(/4,0,0,0/)
+BoundaryName=BC_yminus
+BoundaryType=(/4,0,0,0/)
+BoundaryName=BC_zplus
+BoundaryType=(/4,0,0,0/)
+BoundaryName=BC_zminus
+BoundaryType=(/4,0,0,0/)
+BoundaryName=BC_inner
+BoundaryType=(/100,0,0,0/)


### PR DESCRIPTION
- Fixed an issue with inner BCs and external meshes from Cubit (using the Gambit export), where half of the non-unique sides would not by associated with a BC
- Fixed inconsistent inner BCs between zones in hopr internal meshes, where a side could get an inner BC on one side and a regular inner side on the other
- Fixes a bug with the abort subroutine
- Removed duplicate call to ApplyMeshScale, which broke postScaleMesh=T