### PR TITLE
fix ninja workflow

### DIFF
--- a/.github/workflows/cmake-ninja.yml
+++ b/.github/workflows/cmake-ninja.yml
@@ -48,7 +48,7 @@ jobs:
         rpm -U --quiet p7zip-plugins-16.02-31.el8.x86_64.rpm
         dnf install -y epel-release
         dnf config-manager --set-enabled powertools
-        dnf install -y make libasan gcc-gfortran gcc-c++ unzip openblas-devel lapack-devel zlib-devel tree fuse-sshfs fuse-libs file
+        dnf install -y make gcc-gfortran gcc-c++ unzip openblas-devel lapack-devel zlib-devel tree fuse-sshfs fuse-libs file
         groupadd fuse
         user="$(whoami)"
         usermod -a -G fuse "$user"

--- a/.github/workflows/cmake-ninja.yml
+++ b/.github/workflows/cmake-ninja.yml
@@ -46,10 +46,10 @@ jobs:
         curl -L -O https://github.com/Kitware/CMake/releases/download/v3.16.4/cmake-3.16.4-Linux-x86_64.sh
         chmod +x cmake-3.16.4-Linux-x86_64.sh
         ./cmake-3.16.4-Linux-x86_64.sh --skip-license --prefix=/usr/local
-        curl -L -O https://www.mirrorservice.org/sites/dl.fedoraproject.org/pub/epel/8/Everything/x86_64/Packages/p/p7zip-16.02-20.el8.x86_64.rpm
-        curl -L -O https://www.mirrorservice.org/sites/dl.fedoraproject.org/pub/epel/8/Everything/x86_64/Packages/p/p7zip-plugins-16.02-20.el8.x86_64.rpm
-        rpm -U --quiet p7zip-16.02-20.el8.x86_64.rpm
-        rpm -U --quiet p7zip-plugins-16.02-20.el8.x86_64.rpm
+        curl -L -O https://www.mirrorservice.org/sites/dl.fedoraproject.org/pub/epel/8/Everything/x86_64/Packages/p/p7zip-16.02-31.el8.x86_64.rpm
+        curl -L -O https://www.mirrorservice.org/sites/dl.fedoraproject.org/pub/epel/8/Everything/x86_64/Packages/p/p7zip-plugins-16.02-31.el8.x86_64.rpm
+        rpm -U --quiet p7zip-16.02-31.el8.x86_64.rpm
+        rpm -U --quiet p7zip-plugins-16.02-31.el8.x86_64.rpm
         yum install -y epel-release
         yum install -y 'dnf-command(config-manager)'
         yum config-manager --set-enabled powertools

--- a/.github/workflows/cmake-ninja.yml
+++ b/.github/workflows/cmake-ninja.yml
@@ -43,9 +43,9 @@ jobs:
       run: |
         git config --global --add safe.directory '*'
         git status
-        curl -L -O https://github.com/Kitware/CMake/releases/download/v3.16.4/cmake-3.16.4-Linux-x86_64.sh
-        chmod +x cmake-3.16.4-Linux-x86_64.sh
-        ./cmake-3.16.4-Linux-x86_64.sh --skip-license --prefix=/usr/local
+        curl -L -O https://github.com/Kitware/CMake/releases/download/v3.22.1/cmake-3.22.1-linux-x86_64.sh
+        chmod +x cmake-3.22.1-linux-x86_64.sh
+        ./cmake-3.22.1-linux-x86_64.sh --skip-license --prefix=/usr/local
         curl -L -O https://www.mirrorservice.org/sites/dl.fedoraproject.org/pub/epel/8/Everything/x86_64/Packages/p/p7zip-16.02-31.el8.x86_64.rpm
         curl -L -O https://www.mirrorservice.org/sites/dl.fedoraproject.org/pub/epel/8/Everything/x86_64/Packages/p/p7zip-plugins-16.02-31.el8.x86_64.rpm
         rpm -U --quiet p7zip-16.02-31.el8.x86_64.rpm

--- a/.github/workflows/cmake-ninja.yml
+++ b/.github/workflows/cmake-ninja.yml
@@ -17,20 +17,16 @@ jobs:
     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
     runs-on: ubuntu-latest
 
-    # Use centos8
+    # Use Rocky Linux 8.10
     container:
-      image: centos:8
+      image: rockylinux/rockylinux:8.10
       options: --privileged
 
     steps:
     - name: Install GIT
       shell: bash
       run: |
-        cd /etc/yum.repos.d/
-        sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
-        sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
-        yum -y install https://packages.endpointdev.com/rhel/8/main/x86_64/endpoint-repo.noarch.rpm
-        yum -y install git
+        dnf -y install git
         git --version
 
     - name: Checkout repository including the .git directory
@@ -50,10 +46,9 @@ jobs:
         curl -L -O https://www.mirrorservice.org/sites/dl.fedoraproject.org/pub/epel/8/Everything/x86_64/Packages/p/p7zip-plugins-16.02-31.el8.x86_64.rpm
         rpm -U --quiet p7zip-16.02-31.el8.x86_64.rpm
         rpm -U --quiet p7zip-plugins-16.02-31.el8.x86_64.rpm
-        yum install -y epel-release
-        yum install -y 'dnf-command(config-manager)'
-        yum config-manager --set-enabled powertools
-        yum install -y make libasan gcc-gfortran gcc-c++ unzip openblas-devel lapack-devel zlib-devel tree fuse-sshfs fuse-libs file
+        dnf install -y epel-release
+        dnf config-manager --set-enabled powertools
+        dnf install -y make libasan gcc-gfortran gcc-c++ unzip openblas-devel lapack-devel zlib-devel tree fuse-sshfs fuse-libs file
         groupadd fuse
         user="$(whoami)"
         usermod -a -G fuse "$user"

--- a/cmake/SetLibraries.cmake
+++ b/cmake/SetLibraries.cmake
@@ -199,7 +199,6 @@ ELSE()
       GIT_PROGRESS       TRUE
       ${${GITSHALLOW}}
       PREFIX             ${LIBS_HDF5_DIR}
-      INSTALL_DIR        ${LIBS_HDF5_DIR}
       UPDATE_COMMAND     ""
       # HDF5 explicitely needs "make" to configure
       CMAKE_GENERATOR    "Unix Makefiles"
@@ -547,7 +546,6 @@ ELSE()
         GIT_PROGRESS       TRUE
         ${${GITSHALLOW}}
         PREFIX             ${LIBS_CGNS_DIR}
-        INSTALL_DIR        ${LIBS_CGNS_DIR}
         # Set parallel build with maximum number of threads
         BUILD_COMMAND      ${BUILD_COMMAND} -j${N}
         # Set the CMake arguments for CGNS

--- a/cmake/SetLibraries.cmake
+++ b/cmake/SetLibraries.cmake
@@ -208,7 +208,7 @@ ELSE()
       CMAKE_ARGS         -DCMAKE_BUILD_TYPE=None -DCMAKE_INSTALL_PREFIX=${LIBS_HDF5_DIR} -DHDF5_INSTALL_CMAKE_DIR=lib/cmake/hdf5 -DCMAKE_POLICY_DEFAULT_CMP0175=OLD -DBUILD_STATIC_LIBS=ON -DBUILD_SHARED_LIBS=OFF -DHDF5_BUILD_FORTRAN=ON -DHDF5_ENABLE_Z_LIB_SUPPORT=OFF -DHDF5_ENABLE_SZIP_SUPPORT=OFF -DHDF5_ENABLE_PARALLEL=OFF
       # Set the build byproducts
       # WARNING: The order of the following libraries matters! They need to be listed from the most dependent to the least dependent.
-      INSTALL_BYPRODUCTS ${LIBS_HDF5_DIR}/lib/libhdf5_fortran.a ${LIBS_HDF5_DIR}/lib/libhdf5_f90cstub.a ${LIBS_HDF5_DIR}/lib/libhdf5_hl_fortran.a ${LIBS_HDF5_DIR}/lib/libhdf5_hl_f90cstub.a ${LIBS_HDF5_DIR}/lib/libhdf5_hl.a ${LIBS_HDF5_DIR}/lib/libhdf5.a ${LIBS_HDF5_DIR}/lib/libhdf5_tools.a ${LIBS_HDF5_DIR}/bin/h5diff
+      BUILD_BYPRODUCTS ${LIBS_HDF5_DIR}/lib/libhdf5_fortran.a ${LIBS_HDF5_DIR}/lib/libhdf5_f90cstub.a ${LIBS_HDF5_DIR}/lib/libhdf5_hl_fortran.a ${LIBS_HDF5_DIR}/lib/libhdf5_hl_f90cstub.a ${LIBS_HDF5_DIR}/lib/libhdf5_hl.a ${LIBS_HDF5_DIR}/lib/libhdf5.a ${LIBS_HDF5_DIR}/lib/libhdf5_tools.a ${LIBS_HDF5_DIR}/bin/h5diff
     )
 
     # Add CMake HDF5 to the list of self-built externals
@@ -221,7 +221,7 @@ ELSE()
     # > NOTE: For self-built HDF5, we use a specific version, of which we know the installation directory of the fortran module files
     SET(HDF5_INCLUDE_DIR       ${LIBS_HDF5_DIR}/include)
     SET(HDF5_DIFF_EXECUTABLE   ${LIBS_HDF5_DIR}/bin/h5diff)
-      # WARNING: The order of the following libraries matters! They need to be listed from the most dependent to the least dependent.
+    # WARNING: The order of the following libraries matters! They need to be listed from the most dependent to the least dependent.
     SET(HDF5_LIBRARIES         ${LIBS_HDF5_DIR}/lib/libhdf5_fortran.a ${LIBS_HDF5_DIR}/lib/libhdf5_f90cstub.a ${LIBS_HDF5_DIR}/lib/libhdf5_hl_fortran.a ${LIBS_HDF5_DIR}/lib/libhdf5_hl_f90cstub.a ${LIBS_HDF5_DIR}/lib/libhdf5_hl.a ${LIBS_HDF5_DIR}/lib/libhdf5.a ${LIBS_HDF5_DIR}/lib/libhdf5_tools.a)
   ENDIF()
 


### PR DESCRIPTION
- raise cmake and p7zip versions
- bugfix dependencies self-built HDF5: specify byproducts via `BUILD_PRODUCTS` (instead of `INSTALL_PRODUCTS`)
- change Linux distro in image from CentOS 8 to Rocky 8.10 (same GLIBC version 2.28 but end-of-life May 2029)