### PR TITLE
Compatibility with HDF5 v2.0.0+ and CGNS 4.5.0+

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,10 +74,10 @@ EXECUTE_PROCESS(
   ERROR_QUIET)
 
 FILE(WRITE \"\${buildinfo}\" \"! Define the current commit hash. The default must remain empty, i.e., ''.\n\
-#define GIT_CURRENT_COMMIT '${GIT_COMMIT}'\n\
-#define BUILD_DATE         '${BUILD_DATE}'\n\
-#define BUILD_VERSION_${CMAKE_Fortran_COMPILER_ID}  '${CMAKE_Fortran_COMPILER_VERSION}'\n\
-#define BUILD_VERSION_MPI  'compiled without MPI'\n\
+#define GIT_CURRENT_COMMIT \\\"\${GIT_COMMIT}\\\"\n\
+#define BUILD_DATE         \\\"\${BUILD_DATE}\\\"\n\
+#define BUILD_VERSION_${CMAKE_Fortran_COMPILER_ID}  \\\"${CMAKE_Fortran_COMPILER_VERSION}\\\"\n\
+#define BUILD_VERSION_MPI  \\\"compiled without MPI\\\"\n\
 \")
 ")
 

--- a/cmake/SetLibraries.cmake
+++ b/cmake/SetLibraries.cmake
@@ -113,6 +113,13 @@ IF(NOT LIBS_BUILD_HDF5)
     ENDIF()
   ENDIF()
 
+  # Check if HDF5 is parallel
+  # > NOTE: As of HDF5 v2.0.0 the library variables have been renamed: HDF5_ENABLE_PARALLEL to configure the HDF5 installation, HDF5_PROVIDES_PARALLEL to query the state of the installation.
+  #         This has been adopted by FindHDF5 as of CMake v4.3.0, for earlier CMake versions we need to account for it manually (cf. https://gitlab.kitware.com/cmake/cmake/-/merge_requests/11573)
+  IF(${CMAKE_VERSION} VERSION_LESS "4.3.0" AND ${HDF5_VERSION} VERSION_GREATER_EQUAL "2.0.0")
+    SET(HDF5_IS_PARALLEL ${HDF5_PROVIDES_PARALLEL})
+  ENDIF()
+
   # If HDF5 Fortran library is not set, get it from the Fortran target
   IF("${HDF5_C_LIBRARY_hdf5_c}" STREQUAL "")
     GET_PROPERTY(HDF5_C_LIBRARY_hdf5_c TARGET hdf5::hdf5 PROPERTY LOCATION)

--- a/cmake/SetLibraries.cmake
+++ b/cmake/SetLibraries.cmake
@@ -498,8 +498,7 @@ ELSE()
     ADD_COMPILE_DEFINITIONS(PP_CGNS_INT=${LIBS_BUILD_CGNS_INT})
 
     # Set CGNS_Tag
-    # > Current version 4.5.0 has a regression, so stick with 4.4.0
-    SET(CGNS_VERSION "4.4.0")
+    SET(CGNS_VERSION "4.5.2")
     SET(CGNS_TAG     "v${CGNS_VERSION}")
     SET(CGNS_STR     ${CGNS_TAG})
     MARK_AS_ADVANCED(FORCE CGNS_TAG)
@@ -582,10 +581,6 @@ ELSE()
 
   # Set pre-processor flag for CGNS version
   STRING(REPLACE "v" ""  CGNS_VERSION ${CGNS_VERSION})
-  # Warn about version 4.5.0
-  IF("${CGNS_VERSION}" VERSION_EQUAL "4.5.0")
-    MESSAGE(WARNING "CGNS ${CGNS_VERSION} has issues with reading surface meshes. Consider downgrading to v4.4.0")
-  ENDIF()
   MESSAGE(STATUS "Compiling with ${CGNS_BUILD_STATUS} [CGNS] (v${CGNS_VERSION})")
 
   STRING(REPLACE "." ";" VERSION_LIST ${CGNS_VERSION})

--- a/src/readin/readin_CGNS.f90
+++ b/src/readin/readin_CGNS.f90
@@ -112,7 +112,13 @@ nZonesGlob = 0
 ! Let's fetz now
 DO iFile=1,nMeshFiles
   ! Check CGNS file (CG_IS_CGNS_F must NOT be performed after CG_OPEN_F (in OpenBase), leads to an error in the read-in of HDF5-based CGNS files)
+  ! NOTE: As of CGNS v4.5.0, we need to set the filetype manually since files are no longer checked upon opening - and thereby have their filetype set automatically -
+  !       if filetype HDF5 is requested (see changes in function cgns_io.c::cgio_open_file() by commit #0360632). The filetype HDF5, in turn, is set to requested when
+  !       writing files if CGNS is compiled with ENABLE_HDF5=ON (see global variable cgns_filetype in function cgnslist.c::cg_open()).
+  !       Therefore, in scenarios like tutorial 2-02, where HOPR reads CGNS-files in a non-HDF5 format like ADF and then writes the corresponding mesh file in HDF5 format,
+  !       we need to re-set the filetype manually before reading further CGNS-files, e.g. for the surface mesh.
   CALL CG_IS_CGNS_F(TRIM(MeshFileName(iFile)), file_type, iError)
+  CALL CG_SET_FILE_TYPE_F(file_type,iError)
   IF (iError .NE. CG_OK) CALL abort(__STAMP__,'ERROR: Given CGNS file is not supported!')
 
   ! Check CGNS file type (ADF/HDF5)
@@ -124,8 +130,6 @@ DO iFile=1,nMeshFiles
   CASE DEFAULT
     CALL abort(__STAMP__,'ERROR: CGNS file type is unknown!')
   END SELECT
-
-  ! CALL CG_SET_FILE_TYPE_F(CG_FILE_ADF2, iError);
 
   ! Open CGNS file
   CALL OpenBase(TRIM(MeshFileName(iFile)),MODE_READ,md,md,CGNSFile,CGNSBase,.TRUE.)
@@ -1082,7 +1086,7 @@ SUBROUTINE ReadCGNSSurfaceMesh(FirstElem_in,FileName)
 ! This subroutine reads the surface data from an unstructured CGNS file and prepares the element list.
 !===================================================================================================================================
 ! MODULES
-USE MOD_Mesh_Vars,ONLY:tElem,tElemPtr,tSide
+USE MOD_Mesh_Vars,ONLY:tElem,tElemPtr,tSide,MeshDim
 USE MOD_Mesh_Vars,ONLY:getNewElem,getNewNode,getNewSide
 ! IMPLICIT VARIABLE HANDLING
 IMPLICIT NONE
@@ -1101,10 +1105,10 @@ PP_CGNS_INT_TYPE             :: nNodesGlob         ! Total number of nodes in th
 PP_CGNS_INT_TYPE             :: nElemsGlob         ! Total number of elements in mesh file
 PP_CGNS_INT_TYPE             :: nZonesGlob         ! Total number of zones in the mesh.
 INTEGER                      :: CGNSFile,CGNSBase  ! CGNS file handles
-INTEGER                      :: md  ! ?
 INTEGER                      :: file_type  ! ?
 REAL(KIND=4)                 :: version  ! ?
-
+INTEGER                      :: precision
+INTEGER                      :: md
 CHARACTER(LEN=32)            :: CGName             ! necessary data for CGNS
 INTEGER                      :: ZoneType  ! ?
 TYPE(tElemPtr),ALLOCATABLE   :: Elems(:)                            ! Pointer array to elements
@@ -1141,12 +1145,29 @@ INTEGER(CGSIZE_T),ALLOCATABLE:: connect_offsets(:)
 CALL ABORT(__STAMP__,'ReadCGNSsurfaceMesh needs compilation with USE_CGNS flag!')
 #else
 WRITE(UNIT_stdOut,*)'Read CGNS Surface File: ',TRIM(FileName)
-! Open CGNS file
-CALL OpenBase(TRIM(FileName),MODE_READ,md,md,CGNSFile,CGNSBase,.TRUE.)
-!CALL CG_OPEN_F(TRIM(MeshFileName(iFile)), CG_MODE_READ, CGNSFile, iError)
-CALL CG_VERSION_F(CGNSFile, version, iError)
-WRITE(UNIT_stdOut,*)'CGNS version:',version
+! Check CGNS file (CG_IS_CGNS_F must NOT be performed after CG_OPEN_F (in OpenBase), leads to an error in the read-in of HDF5-based CGNS files)
+! NOTE: As of CGNS v4.5.0, we need to set the filetype manually, see the note in ReadCGNSMesh above
 CALL CG_IS_CGNS_F(TRIM(FileName), file_type, iError)
+CALL CG_SET_FILE_TYPE_F(file_type,iError)
+IF (iError .NE. CG_OK) CALL abort(__STAMP__,'ERROR: Given CGNS file is not supported!')
+
+! Check CGNS file type (ADF/HDF5)
+SELECT CASE(file_type)
+CASE(CG_FILE_ADF)
+  WRITE(UNIT_stdOut,*)'CGNS file type: ADF'
+CASE(CG_FILE_HDF5)
+  WRITE(UNIT_stdOut,*)'CGNS file type: HDF5'
+CASE DEFAULT
+  CALL abort(__STAMP__,'ERROR: CGNS file type is unknown!')
+END SELECT
+
+! Open CGNS file
+md = MeshDim
+CALL OpenBase(TRIM(FileName),MODE_READ,md,md,CGNSFile,CGNSBase,.TRUE.)
+  ! Output CGNS version and precision
+  CALL CG_VERSION_F(CGNSFile, version, iError)
+  CALL CG_PRECISION_F(CGNSFile,precision,iError)
+  WRITE(UNIT_stdOut,*)'CGNS version:', version, ' CGNS precision:', precision, 'Bit'
 
 ! Get number of bases in CGNS file
 CALL CG_NBASES_F(CGNSfile,nBases,iError)


### PR DESCRIPTION
- HDF5 v2.0.0+: account for renamed library state variables `HDF5_ENABLE_PARALLEL` -> `HDF5_PROVIDES_PARALLEL`
- CGNS v4.5.0+: when turning multiple CGNS-files into HDF5 mesh files, ensure to set filetype before each read-in manually
- minor fix to prevent partially empty build information