### PR TITLE
Fix deprecation warnings for GitHub workflows

### DIFF
--- a/.github/workflows/cmake-make.yml
+++ b/.github/workflows/cmake-make.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
 
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.

--- a/.github/workflows/cmake-ninja.yml
+++ b/.github/workflows/cmake-ninja.yml
@@ -30,7 +30,7 @@ jobs:
         git --version
 
     - name: Checkout repository including the .git directory
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         fetch-depth: 0
 
@@ -117,7 +117,7 @@ jobs:
         mv ${BINARYNAME} md5sum.txt artifacts/.
 
     - name: Upload artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: hopr-binary-v1.5.0
         path: artifacts


### PR DESCRIPTION
Fix deprecation warnings due to GitHub actions checkout v3/v4 and upload-artifacts v4